### PR TITLE
Update to java 21

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: "['11']"
+        default: "['21']"
         required: false
         type: string
       preserve-cache-between-runs:

--- a/.github/workflows/_sbt_byzantine_tests.yml
+++ b/.github/workflows/_sbt_byzantine_tests.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: "['11']"
+        default: "['21']"
         required: false
         type: string
       preserve-cache-between-runs:
@@ -38,6 +38,12 @@ jobs:
         with:
           fetch-depth: 0 # Need full history to update last modified time.
           submodules: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
 
       - name: git-restore-mtime
         uses: chetan/git-restore-mtime-action@v1

--- a/.github/workflows/_sbt_integration_tests.yml
+++ b/.github/workflows/_sbt_integration_tests.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: "['11']"
+        default: "['21']"
         required: false
         type: string
       preserve-cache-between-runs:
@@ -33,6 +33,12 @@ jobs:
         with:
           fetch-depth: 0 # Need full history to update last modified time.
           submodules: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
 
       - name: git-restore-mtime
         uses: chetan/git-restore-mtime-action@v1

--- a/.github/workflows/_sbt_jar.yml
+++ b/.github/workflows/_sbt_jar.yml
@@ -10,7 +10,7 @@ on:
         type: string
       java-versions:
         description: 'List of Java versions to target.'
-        default: "['11']"
+        default: "['21']"
         required: false
         type: string
       preserve-cache-between-runs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: Bifrost Node Jar (11)
+          name: Bifrost Node Jar (21)
 
       - name: Find JAR
         run: echo "JAR_LOCATION=$(find . -maxdepth 1 -name "*.jar")" >> $GITHUB_ENV


### PR DESCRIPTION
## Purpose
We are pretty far behind on our Java version. This PR updates the `strata-node` Docker image to use the `21-jre` image and updates the GitHub actions to use Java 21 to compile.

## Approach
* Update the Docker image to use the `21-jre` tag
* Update the GitHub workflows to use Java 21.

I branched this from: https://github.com/StrataLab/strata-node/pull/2 so it should wait until that PR is merged.

## Testing
* Connected locally built Docker image to `devnet`.
* Compiled locally
* This CI/CD :smile: 

## Tickets
* n/a
