### PR TITLE
Draft: test buffersize config on ci_cd 

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,7 +1,6 @@
 -Xmx3G
 -Xms1G
 -Xss32M
--Dstorage.diskCache.bufferSize=512
+-Dstorage.diskCache.bufferSize=4096
 -Denvironment.dumpCfgAtStartup=false
 -Dmemory.useUnsafe=false
--Dstorage.diskCache.bufferSize=4096

--- a/.jvmopts
+++ b/.jvmopts
@@ -2,3 +2,6 @@
 -Xms1G
 -Xss32M
 -Dstorage.diskCache.bufferSize=512
+-Denvironment.dumpCfgAtStartup=false
+-Dmemory.useUnsafe=false
+-Dstorage.diskCache.bufferSize=4096


### PR DESCRIPTION
## Purpose
Avoid `nodeIt` issues:

# Problematic frame:
```
# C  [libc.so.6+0xa1743]
# v  ~StubRoutines::jlong_disjoint_arraycopy
```
Local: # JRE version: OpenJDK Runtime Environment GraalVM CE 21.1.0 (11.0.11+8) (build 11.0.11+8-jvmci-21.1-b05)
 

## Approach
Test with config suggested on https://github.com/orientechnologies/orientdb/issues/9194

From documentation:
[storage.diskCache.bufferSize](https://orientdb.com/docs/last/admin/Configuration.html#storagediskcachebuffersize)
Size of disk buffer in megabytes, disk size may be changed at runtime, but if does not enough to contain all pinned pages exception will be thrown.

Setting name...: storage.diskCache.bufferSize
Default value..: **4096** but this is not true
Set at run-time: true

Locally tested with : -Denvironment.dumpCfgAtStartup=true, with value

 + storage.diskCache.bufferSize = 512

## Testing
Local
## Tickets
*

