### PR TITLE
Move Push CI/CD trigger back to main branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: Push
 on:
   push:
     branches:
-      - "*"
+      - "main"
 
 jobs:
   sbt-build:


### PR DESCRIPTION
## Purpose
https://github.com/StrataLab/strata-node/pull/5 was merged, but I forgot to revert the testing change for the `push.yml` GitHub action.

This PR reverts the trigger back to main.

## Approach
* Update `push.yml` trigger back to main branch.

## Testing
n/a
