### PR TITLE
Fix Docker Image Publishing for GHCR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val nodeDockerSettings =
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
           DockerAlias(Some("docker.io"), Some("stratalab"), "strata-node", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("stratalab"), "strata-node", Some("dev"))
+          DockerAlias(Some("ghcr.io"), Some("plasmalaboratories"), "strata-node", Some("dev"))
         )
       else Seq()
       )
@@ -95,7 +95,7 @@ lazy val indexerDockerSettings =
       if (sys.env.get("DOCKER_PUBLISH_DEV_TAG").fold(false)(_.toBoolean))
         Seq(
           DockerAlias(Some("docker.io"), Some("stratalab"), "strata-indexer", Some("dev")),
-          DockerAlias(Some("ghcr.io"), Some("stratalab"), "strata-indexer", Some("dev"))
+          DockerAlias(Some("ghcr.io"), Some("plasmalaboratories"), "strata-indexer", Some("dev"))
         )
       else Seq()
       )

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val dockerSettings = Seq(
   dockerAliases := dockerAliases.value.flatMap { alias =>
     Seq(
       alias.withRegistryHost(Some("docker.io/stratalab")),
-      alias.withRegistryHost(Some("ghcr.io/stratalab"))
+      alias.withRegistryHost(Some("ghcr.io/plasmalaboratories"))
     )
   }
 )


### PR DESCRIPTION
## Purpose
After rename, need to update ghcr docker image to be `plasmalaboratories`.

The rename to `plasma-node` will happen in the future.

## Approach
* Fix ghcr image name

## Testing

## Tickets
* n/a