### PR TITLE
Basic Ethereum JSON RPC

### DIFF
--- a/config/src/main/scala/org/plasmalabs/config/ApplicationConfig.scala
+++ b/config/src/main/scala/org/plasmalabs/config/ApplicationConfig.scala
@@ -26,6 +26,7 @@ object ApplicationConfig {
     staking:             Node.Staking,
     p2p:                 Node.P2P,
     rpc:                 Node.RPC,
+    ethereumJsonRpc:     Node.EthereumJsonRpc,
     mempool:             Node.Mempool,
     bigBang:             Node.BigBang,
     maxSupportedVersion: Int = 1,
@@ -108,6 +109,9 @@ object ApplicationConfig {
 
     @Lenses
     case class RPC(bindHost: String, bindPort: Int, networkControl: Boolean = false)
+
+    @Lenses
+    case class EthereumJsonRpc(bindHost: String, bindPort: Int)
 
     @Lenses
     case class Mempool(defaultExpirationSlots: Long, protection: MempoolProtection = MempoolProtection())

--- a/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
@@ -1,4 +1,4 @@
-package xyz.stratalab.grpc
+package org.plasmalabs.grpc
 
 import cats.data.OptionT
 import cats.effect.{Async, Resource}
@@ -14,12 +14,12 @@ import org.http4s.dsl.Http4sDslBinCompat
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 import org.http4s.server.middleware.CORS
+import org.plasmalabs.blockchain.{BigBang, BlockchainCore}
+import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.consensus.models.BlockHeader
+import org.plasmalabs.typeclasses.implicits.showBlockId
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
-import xyz.stratalab.blockchain.{BigBang, BlockchainCore}
-import xyz.stratalab.codecs.bytes.tetra.instances._
-import xyz.stratalab.consensus.models.BlockHeader
-import xyz.stratalab.typeclasses.implicits.showBlockId
 
 object EthereumJsonRpc {
 

--- a/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
@@ -178,6 +178,7 @@ object JsonRpcResponse {
  * Ethereum JSON-RPC has many manyn more methods than what is listed here, but most either can't or don't need to be supported.
  */
 trait EthereumRpcMethods[F[_]] {
+
   /**
    * Chain Height
    */
@@ -196,7 +197,7 @@ trait EthereumRpcMethods[F[_]] {
   /**
    * The balances of some address
    */
-  def getBalance(address:   String, block:                Option[String]): F[String]
+  def getBalance(address: String, block: Option[String]): F[String]
 
   /**
    * Retrieve block by height

--- a/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
@@ -1,0 +1,213 @@
+package xyz.stratalab.grpc
+
+import cats.data.OptionT
+import cats.effect.{Async, Resource}
+import cats.implicits._
+import com.comcast.ip4s.{Host, Port}
+import fs2.io.net.Network
+import io.circe._
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec._
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDslBinCompat
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.Router
+import org.http4s.server.middleware.CORS
+import org.typelevel.log4cats.Logger
+import scodec.bits.ByteVector
+import xyz.stratalab.blockchain.{BigBang, BlockchainCore}
+import xyz.stratalab.typeclasses.implicits.showBlockId
+
+object EthereumJsonRpc {
+
+  def serve[F[_]: Async: Network: Logger](bindHost: String, bindPort: Int)(
+    methods: EthereumRpcMethods[F]
+  ): Resource[F, Unit] =
+    Resource
+      .eval(
+        Async[F]
+          .delay(
+            (Host.fromString(bindHost), Port.fromInt(bindPort)).tupled
+              .toRight(new IllegalArgumentException("Invalid bindHost/bindPort"))
+          )
+          .rethrow
+      )
+      .flatMap { case (host, port) =>
+        EmberServerBuilder
+          .default[F]
+          .withHost(host)
+          .withPort(port)
+          .withHttpApp(
+            CORS.policy.withAllowOriginAll.withAllowMethodsAll
+              .withAllowHeadersAll(
+                Router("/" -> routes[F](methods))
+              )
+              .orNotFound
+          )
+          .build
+          .evalTap(_ => Logger[F].info(s"JSON RPC server started on $host:$port"))
+      }
+      .void
+
+  def routes[F[_]: Async: Logger](methods: EthereumRpcMethods[F]): HttpRoutes[F] = {
+    val dsl = new Http4sDslBinCompat[F] {}
+    import JsonRpcRequest._
+    import dsl._
+    HttpRoutes.of[F] {
+      case GET -> Root => Ok()
+      case req @ POST -> Root =>
+        req
+          .as[JsonRpcRequest]
+          .flatMap(request =>
+            (request.method match {
+              case "eth_blockNumber" =>
+                methods.blockNumber.map(number => request.successResponse(s"0x${number.toHexString}".asJson))
+              case "eth_chainId" =>
+                methods.chainId.map(number => request.successResponse(s"0x${number.toHexString}".asJson))
+              case "eth_getBlockByNumber" =>
+                (
+                  Async[F].fromEither(request.params.head.as[String]),
+                  Async[F].fromEither(request.params.lift(1).fold[Decoder.Result[Boolean]](Right(false))(_.as[Boolean]))
+                ).tupled
+                  .flatMap { case (num, hydrate) => methods.blockByNumber(num, hydrate) }
+                  .map(_.getOrElse(Json.Null))
+                  .map(request.successResponse)
+              case "eth_getBalance" =>
+                (
+                  Async[F].fromEither(request.params.head.as[String]),
+                  Async[F].fromEither(request.params.lift(1).traverse(_.as[String]))
+                ).tupled
+                  .flatMap { case (address, block) => methods.getBalance(address, block) }
+                  .map(number => request.successResponse(number.asJson))
+              case "net_version" =>
+                methods.netVersion
+                  .map(_.asJson)
+                  .map(request.successResponse)
+              case _ =>
+                request.errorResponse(-32601, "Method not found").pure[F]
+            })
+              .recoverWith { case e =>
+                Logger[F].warn(e)("Ethereum JSON RPC Error").as(request.errorResponse(-32603, "Borked"))
+              }
+              .map(_.asJson)
+              .map(Response().withEntity(_))
+          )
+    }
+  }
+
+}
+
+case class JsonRpcRequest(jsonrpc: String = "2.0", method: String, params: List[Json], id: Option[Json]) {
+  def successResponse(result: Json): JsonRpcResponse = JsonRpcSuccess(jsonrpc, result, id)
+
+  def errorResponse(code: Int, message: String, data: Option[Json] = None): JsonRpcResponse =
+    JsonRpcError(jsonrpc, code, message, data, id)
+}
+
+object JsonRpcRequest {
+
+  implicit val jsonRpcRequestDecoder: Decoder[JsonRpcRequest] =
+    c =>
+      for {
+        jsonRpc <- c.get[String]("jsonrpc")
+        method  <- c.get[String]("method")
+        params  <- c.get[List[Json]]("params")
+        id      <- c.get[Option[Json]]("id")
+      } yield JsonRpcRequest(jsonRpc, method, params, id)
+
+  implicit val jsonRpcRequestEncoder: Encoder[JsonRpcRequest] =
+    r =>
+      Json.obj(
+        "jsonrpc" -> r.jsonrpc.asJson,
+        "method"  -> r.method.asJson,
+        "params"  -> r.params.asJson,
+        "id"      -> r.id.asJson
+      )
+}
+
+sealed abstract class JsonRpcResponse
+case class JsonRpcSuccess(jsonrpc: String = "2.0", result: Json, id: Option[Json]) extends JsonRpcResponse
+
+case class JsonRpcError(jsonrpc: String = "2.0", code: Int, message: String, data: Option[Json], id: Option[Json])
+    extends JsonRpcResponse
+
+object JsonRpcResponse {
+
+  implicit val jsonRpcResponseEncoder: Encoder[JsonRpcResponse] = {
+    case JsonRpcSuccess(jsonrpc, result, id) =>
+      Json.obj(
+        "jsonrpc" -> jsonrpc.asJson,
+        "result"  -> result,
+        "id"      -> id.asJson
+      )
+    case JsonRpcError(jsonrpc, code, message, data, id) =>
+      Json.obj(
+        "jsonrpc" -> jsonrpc.asJson,
+        "error"   -> Json.obj("code" -> code.asJson, "message" -> message.asJson, "data" -> data.asJson),
+        "id"      -> id.asJson
+      )
+  }
+}
+
+trait EthereumRpcMethods[F[_]] {
+  def blockNumber: F[Long]
+  def chainId: F[Long]
+  def netVersion: F[String]
+  def getBalance(address:   String, block:                Option[String]): F[String]
+  def blockByNumber(number: String, hydratedTransactions: Boolean): F[Option[Json]]
+}
+
+class EthereumJsonRpcImpl[F[_]: Async](core: BlockchainCore[F]) extends EthereumRpcMethods[F] {
+
+  override def blockNumber: F[Long] = core.consensus.localChain.head.map(_.height)
+
+  override def chainId: F[Long] = 69420L.pure[F]
+
+  override def netVersion: F[String] = "69420".pure[F]
+
+  override def blockByNumber(number: String, hydratedTransactions: Boolean): F[Option[Json]] =
+    Async[F]
+      .delay(number match {
+        case "earliest"              => BigBang.Height
+        case "finalized"             => -10L // TODO
+        case "safe"                  => -5L
+        case "latest"                => 0L
+        case v if v.startsWith("0x") => java.lang.Long.parseLong(v.drop(2), 16)
+        case v                       => v.toLong
+      })
+      .flatMap(height =>
+        OptionT(core.consensus.localChain.blockIdAtHeight(height))
+          .semiflatMap(id =>
+            core.dataStores.headers
+              .getOrRaise(id)
+              .map(header =>
+                Json.obj(
+                  "hash"            -> s"0x${ByteVector(id.value.toByteArray).toHex}".asJson,
+                  "parentHash"      -> s"0x${ByteVector(header.parentHeaderId.value.toByteArray).toHex}".asJson,
+                  "sha3Uncles"      -> ("0x" + Array.fill(64)("0").mkString).asJson,
+                  "miner"           -> ("0x" + Array.fill(64)("40").mkString).asJson,
+                  "stateRoot"       -> ("0x" + Array.fill(64)("0").mkString).asJson,
+                  "transactionRoot" -> ("0x" + Array.fill(64)("0").mkString).asJson,
+                  "receiptsRoot"    -> ("0x" + Array.fill(64)("0").mkString).asJson,
+                  "logsBloom"       -> ("0x" + Array.fill(512)("0").mkString).asJson,
+                  "difficulty"      -> "0x0".asJson,
+                  "number"          -> s"0x${header.height.toHexString}".asJson,
+                  "gasLimit"        -> "0x0".asJson,
+                  "gasUsed"         -> "0x0".asJson,
+                  "timestamp"       -> s"0x${header.timestamp.toHexString}".asJson,
+                  "extraData"       -> "0x0".asJson,
+                  "mixHash"         -> ("0x" + Array.fill(64)("0").mkString).asJson,
+                  "nonce"           -> ("0x" + Array.fill(16)("0").mkString).asJson,
+                  "size"            -> s"0x${header.toByteArray.length.toHexString}".asJson,
+                  "transactions"    -> Json.arr(),
+                  "withdrawals"     -> Json.arr(),
+                  "uncles"          -> Json.arr()
+                )
+              )
+          )
+          .value
+      )
+
+  override def getBalance(address: String, block: Option[String]): F[String] = "0xeb344079513a1300000".pure[F]
+}

--- a/node-it/src/test/scala/org/plasmalabs/node/NodeAppTest.scala
+++ b/node-it/src/test/scala/org/plasmalabs/node/NodeAppTest.scala
@@ -67,6 +67,8 @@ class NodeAppTest extends CatsEffectSuite {
          |    known-peers: 127.0.0.2:9150
          |  rpc:
          |    bind-port: 9153
+         |  ethereum-json-rpc:
+         |    bind-port: 8546
          |  big-bang:
          |    type: public
          |    genesis-id: ${genesisBlockId.show}

--- a/node-it/src/test/scala/org/plasmalabs/node/NodeNetworkControlTest.scala
+++ b/node-it/src/test/scala/org/plasmalabs/node/NodeNetworkControlTest.scala
@@ -26,10 +26,12 @@ class NodeNetworkControlTest extends CatsEffectSuite {
   val nodeAIp = "127.0.0.2"
   val nodeAP2PPort = 9150
   val nodeARpcPort = 9151
+  val nodeAEthRpcPort = 8545
 
   val nodeBIp = "localhost"
   val nodeBP2PPort = 9152
   val nodeBRpcPort = 9153
+  val nodeBEthRpcPort = 8546
 
   test("Two block-producing nodes that maintain consensus") {
     def configNodeA(dataDir: Path, stakingDir: Path, genesisBlockId: BlockId, genesisSourcePath: String): String =
@@ -45,6 +47,8 @@ class NodeNetworkControlTest extends CatsEffectSuite {
          |  rpc:
          |    bind-port: $nodeARpcPort
          |    network-control: true
+         |  ethereum-json-rpc:
+         |    bind-port: $nodeAEthRpcPort
          |  big-bang:
          |    type: public
          |    genesis-id: ${genesisBlockId.show}
@@ -70,6 +74,8 @@ class NodeNetworkControlTest extends CatsEffectSuite {
          |  rpc:
          |    bind-port: $nodeBRpcPort
          |    network-control: true
+         |  ethereum-json-rpc:
+         |    bind-port: $nodeBEthRpcPort
          |  big-bang:
          |    type: public
          |    genesis-id: ${genesisBlockId.show}

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -51,6 +51,12 @@ node {
     // The local port for binding at the OS-level to allow outside gRPC connections
     bind-port = 9084
   }
+  ethereum-json-rpc {
+    // The local host/IP for binding at the OS-level to allow outside Ethereum JSON RPC connections
+    bind-host = "0.0.0.0"
+    // The local port for binding at the OS-level to allow outside Ethereum JSON RPC connections
+    bind-port = 8545
+  }
   // Settings for the mempool
   mempool {
     // The maximum number of slots to retain a Transaction that fails to find its way into a block

--- a/node/src/main/scala/org/plasmalabs/version/node/ApplicationConfigOps.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/ApplicationConfigOps.scala
@@ -51,6 +51,12 @@ object ApplicationConfigOps {
         ),
         cmdArgs.runtime.rpcBindHost.map(createF(GenLens[ApplicationConfig](_.node.rpc.bindHost))),
         cmdArgs.runtime.rpcBindPort.map(createF(GenLens[ApplicationConfig](_.node.rpc.bindPort))),
+        cmdArgs.runtime.ethereumJsonRpcBindHost.map(
+          createF(GenLens[ApplicationConfig](_.node.ethereumJsonRpc.bindHost))
+        ),
+        cmdArgs.runtime.ethereumJsonRpcBindPort.map(
+          createF(GenLens[ApplicationConfig](_.node.ethereumJsonRpc.bindPort))
+        ),
         cmdArgs.runtime.p2pBindHost.map(createF(GenLens[ApplicationConfig](_.node.p2p.bindHost))),
         cmdArgs.runtime.p2pBindPort.map(createF(GenLens[ApplicationConfig](_.node.p2p.bindPort))),
         cmdArgs.runtime.p2pPublicHost.map(v => createF(GenLens[ApplicationConfig](_.node.p2p.publicHost))(v.some)),

--- a/node/src/main/scala/org/plasmalabs/version/node/Args.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/Args.scala
@@ -69,6 +69,14 @@ object Args {
     )
     rpcBindPort: Option[Int] = None,
     @arg(
+      doc = "The hostname to bind to for the Ethereum JSON-RPC layer (i.e. localhost or 0.0.0.0)"
+    )
+    ethereumJsonRpcBindHost: Option[String] = None,
+    @arg(
+      doc = "The port to bind to for the Ethereum JSON-RPC layer (i.e. 8545)"
+    )
+    ethereumJsonRpcBindPort: Option[Int] = None,
+    @arg(
       doc = "The hostname to bind to for the P2P layer (i.e. localhost or 0.0.0.0)"
     )
     p2pBindHost: Option[String] = None,

--- a/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
@@ -25,7 +25,7 @@ import org.plasmalabs.consensus.models.{BlockId, VrfConfig}
 import org.plasmalabs.crypto.hash.Blake2b512
 import org.plasmalabs.crypto.signing.Ed25519
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.grpc.HealthCheckGrpc
+import org.plasmalabs.grpc._
 import org.plasmalabs.healthcheck.HealthCheck
 import org.plasmalabs.indexer._
 import org.plasmalabs.interpreters._
@@ -37,7 +37,6 @@ import org.plasmalabs.models.p2p._
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
 import org.plasmalabs.models.utility._
 import org.plasmalabs.networking.p2p.LocalPeer
-import org.plasmalabs.node.ApplicationConfigOps._
 import org.plasmalabs.node.cli.ConfiguredCliApp
 import org.plasmalabs.numerics.interpreters.{ExpInterpreter, Log1pInterpreter}
 import org.plasmalabs.sdk.validation.{TransactionCostCalculatorInterpreter, TransactionCostConfig}

--- a/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
@@ -49,6 +49,8 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.time.Instant
 import scala.concurrent.duration._
 
+import ApplicationConfigOps._
+
 object NodeApp extends AbstractNodeApp
 
 abstract class AbstractNodeApp
@@ -730,6 +732,10 @@ class ConfiguredNodeApp(args: Args, appConfig: ApplicationConfig) {
         validatorsP2P,
         epochData,
         protocolConfig
+      )
+
+      _ <- EthereumJsonRpc.serve(appConfig.node.ethereumJsonRpc.bindHost, appConfig.node.ethereumJsonRpc.bindPort)(
+        new EthereumJsonRpcImpl(localBlockchain)
       )
 
       // Finally, run the program

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,7 +100,8 @@ object Dependencies {
 
   val http4s = Seq(
     "org.http4s" %% "http4s-ember-client" % http4sVersion,
-    "org.http4s" %% "http4s-dsl"          % http4sVersion
+    "org.http4s" %% "http4s-dsl"          % http4sVersion,
+    "org.http4s" %% "http4s-circe"        % http4sVersion
   )
 
   val http4sServer = http4s ++ Seq(
@@ -247,7 +248,7 @@ object Dependencies {
     Seq(
       "io.grpc" % "grpc-netty-shaded" % ioGrpcVersion,
       grpcServices
-    )
+    ) ++ http4sServer
 
   lazy val levelDbStore: Seq[ModuleID] =
     levelDb ++


### PR DESCRIPTION
## Purpose
- To integrate with Ethereum-based wallets, we need to offer an Ethereum JSON-RPC compatible API
## Approach
- Use MetaMask with custom network to backtrack which calls are necessary to implement
- Reference [Ethereum JSON-RPC Spec](https://ethereum.github.io/execution-apis/api-documentation/) for methods/requests/responses
- Implement the 5 needed RPC methods for basic integration
  - Note: More will likely be required in the future (i.e. submitting a transaction)
- Serve on port 8545 by default, to match normal Ethereum RPC nodes 
## Testing
- Verified integration with MetaMask
## Tickets
- #BN-1593