### PR TITLE
BN[hotix] SanityCheckNodeTest testing on cicd, the new retray delay for sanity test, locally works,…

### DIFF
--- a/byzantine-it/src/test/scala/org/plasmalabs/byzantine/util/IndexerRpcApi.scala
+++ b/byzantine-it/src/test/scala/org/plasmalabs/byzantine/util/IndexerRpcApi.scala
@@ -18,9 +18,9 @@ class IndexerRpcApi[F[_]](val client: IndexerRpc[F]) extends AnyVal {
           .retry(
             client
               .blockIdAtHeight(1),
-            250.milli,
+            1.minute, // In case of failures, ttl cache will expire on 1 minute by config
             identity,
-            200
+            3
           )
           .compile
           .lastOrError


### PR DESCRIPTION
… with and without this change

## Purpose

`==> X org.plasmalabs.byzantine.SanityCheckNodeTest.A single node is successfully started, id of the genesis block is available through RPC  65.087s io.grpc.StatusRuntimeException: INTERNAL: Indexer canonical head height:[2] differs to Node head[3]`

In build: https://github.com/PlasmaLaboratories/plasma-node/actions/runs/11480045651/job/31950103054

## Approach
increment retry delay on waitForRpcStartUp
## Testing

```
11:23:23.647| INFO  [io-compute-blocker-7] DockerNode(5197bf10) - Stopping
11:23:24.752| INFO  [io-compute-blocker-7] DockerNode(5197bf10) - Writing container logs to byzantine-it/target/logs/SingleNodeTest-node1-5197bf10.log
org.plasmalabs.byzantine.SanityCheckNodeTest:
  + A single node is successfully started, id of the genesis block is available through RPC 69.648s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 74 s (01:14), completed Oct 23, 2024, 11:23:25 AM

```

## Tickets
*
