### PR TITLE
Fix Release Artifact Download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: Strata Node Jar (11)
+          name: Strata Node Jar (21)
 
       - name: Find JAR
         run: echo "JAR_LOCATION=$(find . -maxdepth 1 -name "*.jar")" >> $GITHUB_ENV


### PR DESCRIPTION
## Purpose
In previous PRs, we updated to Java21 for the node. This also updated the artifact name we are sharing across GitHub action jobs.

https://github.com/PlasmaLaboratories/plasma-node/actions/runs/11482938530/job/31959204591

The release job was not updated, so it was trying to pull an artifact named `Strata Node Jar (11)` when it should be pulling `Strata Node Jar (21)`.

## Approach
Update release artifact name.

## Testing
n/a

## Tickets
n/a