### PR TITLE
Remove wart remever Update plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,6 @@ Seq(
   "pl.project13.scala" % "sbt-jmh"                   % "0.4.7",
   "org.scalameta"      % "sbt-scalafmt"              % "2.5.2",
   "ch.epfl.scala"      % "sbt-scalafix"              % "0.13.0",
-  "org.wartremover"    % "sbt-wartremover"           % "3.1.6",
   "com.github.sbt"     % "sbt-native-packager"       % "1.9.16",
   "com.eed3si9n"       % "sbt-buildinfo"             % "0.11.0",
   "com.github.sbt"     % "sbt-ci-release"            % "1.5.12",


### PR DESCRIPTION
The node actually contains this plugin, which is not used and blocking the dependency udpates,  see https://github.com/PlasmaLaboratories/plasma-node/actions/runs/11759185431/job/32758380055
