### PR TITLE
BN-1646_ethToken_PrivateTestnet

### DIFF
--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/PrivateTestnet.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.blockchain
 
 import cats.effect.Async
-import cats.implicits.*
+import cats.implicits._
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
@@ -12,17 +12,18 @@ import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.consensus.models.ProtocolVersion
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
-import org.plasmalabs.models.*
-import org.plasmalabs.models.utility.*
-import org.plasmalabs.numerics.implicits.*
+import org.plasmalabs.models._
+import org.plasmalabs.models.utility._
+import org.plasmalabs.numerics.implicits._
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.models.box.*
+import org.plasmalabs.sdk.models.box._
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, UnspentTransactionOutput}
-import org.plasmalabs.sdk.models.{Datum, Event, LockAddress, TransactionOutputAddress, TransactionId}
-import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.sdk.models.{Datum, Event, LockAddress, TransactionId, TransactionOutputAddress}
+import org.plasmalabs.sdk.syntax._
 import org.typelevel.log4cats.Logger
 import quivr.models.{Int128, Proposition}
-import scala.concurrent.duration.*
+
+import scala.concurrent.duration._
 
 object PrivateTestnet {
 

--- a/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
+++ b/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
@@ -2,14 +2,17 @@ package org.plasmalabs.blockchain
 
 import cats.effect.IO
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.blockchain.PrivateTestnet.DefaultTotalStake
+import org.plasmalabs.blockchain.PrivateTestnet.{DefaultTotalStake, GroupPolicyEth, SeriesPolicyEth}
+import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalamock.munit.AsyncMockFactory
+import quivr.models.Int128
+import scala.concurrent.duration.FiniteDuration
 
 class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 
@@ -82,6 +85,64 @@ class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite 
 
         }
         .void
+    } yield ()
+  }
+
+  test("Big bang config appended outputs for PrivateTestnet, currentTime, 1 staker") {
+    for {
+      timestamp <- System.currentTimeMillis().pure[F]
+      operator  <- PrivateTestnet.stakerInitializers(timestamp, 1).pure[F]
+      bigBangConfig <- PrivateTestnet
+        .config(
+          timestamp,
+          operator,
+          Some(List(1: BigInt)),
+          PrivateTestnet.DefaultProtocolVersion,
+          // https://plasma-labs.atlassian.net/browse/BN-1667
+          // config module should implement and expose generators for config case classes.
+          protocol = ApplicationConfig.Node
+            .Protocol("", Ratio.One, 1, 1, Ratio.One, Ratio.One, 1L, 1L, FiniteDuration(1, "s"), 1L, 1L, 1, 1, None)
+        )
+        .pure[F]
+
+      // head is the registration transaction wich contains TOPL
+      _ <- assertIO(bigBangConfig.transactions.head.outputs.size.pure[F], 1)
+      // tail is the appended transactio wich contains, LVLs, Proposal, Group, Series, ...
+      _ <- assertIO(bigBangConfig.transactions.tail.head.outputs.size.pure[F], 4)
+
+      appendedOutputs = bigBangConfig.transactions.tail.head.outputs
+
+      _ <- assertIOBoolean(
+        appendedOutputs
+          .map(_.value)
+          .contains(
+            Value.defaultInstance
+              .withGroup(
+                Value.Group(
+                  groupId = GroupPolicyEth.computeId,
+                  quantity = 1L: Int128,
+                  fixedSeries = Some(SeriesPolicyEth.computeId)
+                )
+              )
+          )
+          .pure[F]
+      )
+
+      _ <- assertIOBoolean(
+        appendedOutputs
+          .map(_.value)
+          .contains(
+            Value.defaultInstance
+              .withSeries(
+                Value.Series(
+                  seriesId = SeriesPolicyEth.computeId,
+                  quantity = 1L: Int128
+                )
+              )
+          )
+          .pure[F]
+      )
+
     } yield ()
   }
 

--- a/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
+++ b/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
@@ -2,16 +2,17 @@ package org.plasmalabs.blockchain
 
 import cats.effect.IO
 import cats.effect.kernel.Async
-import cats.implicits.*
+import cats.implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.blockchain.PrivateTestnet.{DefaultTotalStake, GroupPolicyEth, SeriesPolicyEth}
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits.*
+import org.plasmalabs.numerics.implicits._
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.sdk.syntax._
 import org.scalamock.munit.AsyncMockFactory
 import quivr.models.Int128
+
 import scala.concurrent.duration.FiniteDuration
 
 class StakerInitializersSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {


### PR DESCRIPTION
## Purpose
- BN-1646_ethToken_PrivateTestnet
## Approach
- add 2 new outputs, for provate testnet, with index 0 for groupId and index 1 for seriesId. 

## Tickets
BN-1646


![image](https://github.com/user-attachments/assets/926824be-17c3-4df9-9bf9-ead9d1ebcff8)
