### PR TITLE
BN-1636 Transaction verification no longer could throw exception if spent transaction is missed

### DIFF
--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/Validators.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/Validators.scala
@@ -100,7 +100,7 @@ object Validators {
       headerToBody <- BlockHeaderToBodyValidation.make().toResource
       transactionSyntaxValidation = TransactionSyntaxInterpreter.make[F]()
       transactionSemanticValidation <- TransactionSemanticValidation
-        .make[F](dataStores.transactions.getOrRaise, boxState)
+        .make[F](dataStores.transactions.get, boxState)
       transactionAuthorizationValidation = TransactionAuthorizationInterpreter.make[F]()
       rewardCalculator <- TransactionRewardCalculator.make[F]
       bodySyntaxValidation <- BodySyntaxValidation

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/Blockchain.scala
@@ -208,7 +208,7 @@ class BlockchainImpl[F[_]: Async: Random: Dns: Stats](
           _         <- Stream.eval(Logger[F].debug(show"Staking algebra had been built successfully"))
           blockPackerValidation <- Stream.resource(
             TransactionSemanticValidation
-              .makeDataValidation(localBlockchain.dataStores.transactions.getOrRaise)
+              .makeDataValidation(localBlockchain.dataStores.transactions.get)
               .flatMap(
                 BlockPackerValidation.make[F](_, localBlockchain.ledger.transactionAuthorizationValidation)
               )

--- a/ledger/src/main/scala/org/plasmalabs/ledger/models/TransactionSemanticError.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/models/TransactionSemanticError.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.ledger.models
 
 import org.plasmalabs.models.Slot
-import org.plasmalabs.sdk.models.TransactionOutputAddress
 import org.plasmalabs.sdk.models.transaction.{Schedule, SpentTransactionOutput}
+import org.plasmalabs.sdk.models.{TransactionId, TransactionOutputAddress}
 
 sealed abstract class TransactionSemanticError
 
@@ -26,4 +26,10 @@ object TransactionSemanticErrors {
    * @param schedule the transaction's schedule
    */
   case class UnsatisfiedSchedule(slot: Slot, schedule: Schedule) extends TransactionSemanticError
+
+  /**
+   * Input transaction is missed in our transaction store
+   * @param id missed transaction id
+   */
+  case class InputTransactionIsMissed(id: TransactionId) extends TransactionSemanticError
 }


### PR DESCRIPTION
## Purpose
Verification of transaction shall not throw exception, instead correct verification error shall be returned

## Approach
Return error instead of exception

## Testing
Unit tests

## Tickets
BN-1636