### PR TITLE
TSDK-916 Use Scala 3 formatting

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -9,4 +9,5 @@ rules = [
 
 OrganizeImports {
   groupedImports = Merge
+  targetDialect = Scala3
 }

--- a/actor/src/main/scala/org/plasmalabs/actor/Actor.scala
+++ b/actor/src/main/scala/org/plasmalabs/actor/Actor.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.actor
 
 import cats.Applicative
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.Queue
-import cats.effect.syntax.all._
-import cats.syntax.all._
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
 import fs2.Stream
 import fs2.concurrent.SignallingRef
 import org.plasmalabs.actor.Actor.ActorId

--- a/actor/src/test/scala/org/plasmalabs/actor/ActorSpec.scala
+++ b/actor/src/test/scala/org/plasmalabs/actor/ActorSpec.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.actor
 
 import cats.effect.{Concurrent, Deferred, IO, Ref, Resource}
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.actor.ActorSpec._
+import org.plasmalabs.actor.ActorSpec.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger

--- a/algebras/src/main/scala/org/plasmalabs/algebras/ClockAlgebra.scala
+++ b/algebras/src/main/scala/org/plasmalabs/algebras/ClockAlgebra.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.algebras
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Functor, Monad}
 import org.plasmalabs.models.{Epoch, Slot, Timestamp}
 

--- a/algebras/src/main/scala/org/plasmalabs/algebras/NodeRegTestRpc.scala
+++ b/algebras/src/main/scala/org/plasmalabs/algebras/NodeRegTestRpc.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.algebras
 
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 trait NodeRegTestRpc[F[_], S[_]] {
   def setVoting(votingVersion: VersionId, votingProposal: ProposalId): F[Unit]

--- a/algebras/src/main/scala/org/plasmalabs/algebras/Store.scala
+++ b/algebras/src/main/scala/org/plasmalabs/algebras/Store.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.algebras
 
 import cats.data.OptionT
-import cats.implicits._
+import cats.implicits.*
 import cats.{Functor, MonadThrow, Show}
 
 trait StoreReader[F[_], Key, T] {

--- a/algebras/src/main/scala/org/plasmalabs/algebras/StoreOps.scala
+++ b/algebras/src/main/scala/org/plasmalabs/algebras/StoreOps.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.algebras
 
 import cats.MonadThrow
-import cats.implicits._
-import org.plasmalabs.models._
+import cats.implicits.*
+import org.plasmalabs.models.*
 
 object StoreOps {
 

--- a/algebras/src/test/scala/org/plasmalabs/algebras/ClockAlgebraOpsSpec.scala
+++ b/algebras/src/test/scala/org/plasmalabs/algebras/ClockAlgebraOpsSpec.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.algebras
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.models.{Epoch, Slot}
 import org.scalamock.munit.AsyncMockFactory
 
-import ClockAlgebra.implicits._
+import ClockAlgebra.implicits.*
 
 class ClockAlgebraOpsSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/algebras/src/test/scala/org/plasmalabs/algebras/testInterpreters/TestStore.scala
+++ b/algebras/src/test/scala/org/plasmalabs/algebras/testInterpreters/TestStore.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.algebras.testInterpreters
 
 import cats.effect.kernel.{Async, Ref}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.Store
 
 object TestStore {

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/BigBang.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/BigBang.scala
@@ -3,29 +3,29 @@ package org.plasmalabs.blockchain
 import cats.Parallel
 import cats.data.{EitherT, ReaderT}
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration.Duration
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.codecs.bytes.typeclasses.Transmittable
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.consensus.algebras.BlockHeaderToBodyValidationAlgebra
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.hash.Blake2b256
-import org.plasmalabs.models._
-import org.plasmalabs.models.protocol.BigBangConstants._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.protocol.BigBangConstants.*
 import org.plasmalabs.models.protocol.{ConfigConverter, ConfigGenesis}
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
-import org.plasmalabs.models.utility._
-import org.plasmalabs.node.models._
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.node.models.*
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.quivr.models.Ratio
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * The beginning of everything.  ("everything" of course just means the first block of a blockchain)

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/CryptoResources.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/CryptoResources.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.blockchain
 
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.crypto.hash.{Blake2b256, Blake2b512}
-import org.plasmalabs.crypto.signing._
+import org.plasmalabs.crypto.signing.*
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 
 case class CryptoResources[F[_]](

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/DataStores.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/DataStores.scala
@@ -2,13 +2,13 @@ package org.plasmalabs.blockchain
 
 import cats.MonadThrow
 import cats.data.NonEmptySet
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.Path
 import org.plasmalabs.algebras.Store
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.{Epoch, ProposalId, VersionId}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/EventSourcedStates.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/EventSourcedStates.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.blockchain
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Functor, Parallel}
 import org.plasmalabs.blockchain.interpreters.EpochDataEventSourcedState
-import org.plasmalabs.consensus.interpreters._
+import org.plasmalabs.consensus.interpreters.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.EventSourcedState
 import org.plasmalabs.interpreters.{BlockHeightTree, TxIdToBlockIdTree}

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/MempoolProtected.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/MempoolProtected.scala
@@ -2,24 +2,24 @@ package org.plasmalabs.blockchain
 
 import cats.data.EitherT
 import cats.effect.Resource
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Async
 import cats.effect.std.Semaphore
-import cats.implicits._
+import cats.implicits.*
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig.Node.MempoolProtection
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.implicits._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.implicits.*
 import org.plasmalabs.ledger.interpreters.QuivrContext
-import org.plasmalabs.ledger.models._
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{TransactionId, TransactionOutputAddress}
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.validation.algebras.{TransactionAuthorizationVerifier, TransactionCostCalculator}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object MempoolProtected {

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/Validators.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/Validators.scala
@@ -1,22 +1,22 @@
 package org.plasmalabs.blockchain
 
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.{ClockAlgebra, Stats}
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.interpreters.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.interpreters._
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.EventSourcedState
-import org.plasmalabs.ledger.algebras._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.interpreters.*
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.ProposalEventSourceStateType
-import org.plasmalabs.ledger.interpreters._
 import org.plasmalabs.models.{ProposalConfig, VersionId}
 import org.plasmalabs.quivr.api.Verifier.instances.verifierInstance
 import org.plasmalabs.sdk.validation.algebras.{TransactionAuthorizationVerifier, TransactionSyntaxVerifier}
 import org.plasmalabs.sdk.validation.{TransactionAuthorizationInterpreter, TransactionSyntaxInterpreter}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 trait Validators[F[_]] {

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/EpochDataInterpreter.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/EpochDataInterpreter.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.blockchain.interpreters
 
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Sync
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.algebras.{ClockAlgebra, Stats, Store}
 import org.plasmalabs.blockchain.algebras.EpochDataAlgebra
 import org.plasmalabs.codecs.bytes.tetra.TetraScodecCodecs
@@ -14,16 +14,16 @@ import org.plasmalabs.consensus.interpreters.{ConsensusDataEventSourcedState, Ep
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.sdk.common.ContainsImmutable
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * Invokes an EpochDataEventSourcedState implementation along the chain's canonical head to produce EpochData

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/NetworkControlRpcServer.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/NetworkControlRpcServer.scala
@@ -2,12 +2,12 @@ package org.plasmalabs.blockchain.interpreters
 
 import cats.Show
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.concurrent.Topic
 import io.grpc.{Metadata, ServerServiceDefinition}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.{NetworkCommands, byteStringToByteVector}
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 import org.typelevel.log4cats.Logger
 
 object NetworkControlRpcServer {

--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/RegtestRpcServer.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/interpreters/RegtestRpcServer.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.blockchain.interpreters
 
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.{Metadata, ServerServiceDefinition}
 import org.plasmalabs.models.{ProposalId, VersionId}
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 import org.typelevel.log4cats.Logger
 
 /**

--- a/blockchain-core/src/test/scala/org/plasmalabs/blockchain/interpreters/BlockHeaderToBodyValidationSpec.scala
+++ b/blockchain-core/src/test/scala/org/plasmalabs/blockchain/interpreters/BlockHeaderToBodyValidationSpec.scala
@@ -4,9 +4,9 @@ import cats.effect.IO
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.consensus.interpreters.BlockHeaderToBodyValidation
 import org.plasmalabs.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
-import org.plasmalabs.models.generators.node.ModelGenerators._
-import org.plasmalabs.node.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.generators.node.ModelGenerators.*
+import org.plasmalabs.node.models.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/blockchain-core/src/test/scala/org/plasmalabs/blockchain/interpreters/EpochDataInterpreterSpec.scala
+++ b/blockchain-core/src/test/scala/org/plasmalabs/blockchain/interpreters/EpochDataInterpreterSpec.scala
@@ -2,35 +2,35 @@ package org.plasmalabs.blockchain.interpreters
 
 import cats.data.OptionT
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.codecs.bytes.tetra.TetraScodecCodecs
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.interpreters.{ConsensusDataEventSourcedState, EpochBoundariesEventSourcedState}
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.interpreters.SchedulerClock
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.ledger.models.RewardQuantities
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.node.models.{BlockBody, FullBlock, FullBlockBody}
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.common.ContainsImmutable
 import org.plasmalabs.sdk.models.box.{Attestation, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, LockAddress, LockId, TransactionId, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 
 import java.time.Instant
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class EpochDataInterpreterSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/Blockchain.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/Blockchain.scala
@@ -1,46 +1,46 @@
 package org.plasmalabs.blockchain
 
-import cats.data._
-import cats.effect._
-import cats.effect.implicits._
+import cats.data.*
+import cats.effect.*
+import cats.effect.implicits.*
 import cats.effect.std.{Queue, Random}
-import cats.implicits._
+import cats.implicits.*
 import com.comcast.ip4s.Dns
 import fs2.concurrent.Topic
-import fs2.{io => _, _}
+import fs2.{io as _, *}
 import io.grpc.ServerServiceDefinition
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.blockchain.interpreters.{NetworkControlRpcServer, RegtestRpcServer}
-import org.plasmalabs.catsutils._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.catsutils.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig.Node.BigBangs.RegtestConfig
 import org.plasmalabs.config.ApplicationConfig.Node.{KnownPeer, NetworkProperties}
-import org.plasmalabs.consensus._
-import org.plasmalabs.grpc._
-import org.plasmalabs.ledger.implicits._
+import org.plasmalabs.consensus.*
+import org.plasmalabs.grpc.*
+import org.plasmalabs.ledger.implicits.*
 import org.plasmalabs.ledger.interpreters.{QuivrContext, TransactionSemanticValidation}
 import org.plasmalabs.ledger.models.StaticBodyValidationContext
 import org.plasmalabs.minting.algebras.StakingAlgebra
-import org.plasmalabs.minting.interpreters._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.minting.interpreters.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.NetworkCommands
 import org.plasmalabs.models.{ProposalId, VersionId}
-import org.plasmalabs.networking.blockchain._
+import org.plasmalabs.networking.blockchain.*
+import org.plasmalabs.networking.fsnetwork.*
 import org.plasmalabs.networking.fsnetwork.DnsResolverInstances.DefaultDnsResolver
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.ReverseDnsResolverInstances.{DefaultReverseDnsResolver, NoOpReverseResolver}
-import org.plasmalabs.networking.fsnetwork._
-import org.plasmalabs.networking.p2p._
+import org.plasmalabs.networking.p2p.*
 import org.plasmalabs.node.models.{Block, BlockBody, FullBlock, KnownHost}
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
-import org.plasmalabs.typeclasses.implicits._
-import org.typelevel.log4cats._
+import org.plasmalabs.typeclasses.implicits.*
+import org.typelevel.log4cats.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
-import ClockAlgebra.implicits._
+import ClockAlgebra.implicits.*
 
 object Blockchain {
 

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/PrivateTestnet.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/PrivateTestnet.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.blockchain
 
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
@@ -12,18 +12,18 @@ import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.consensus.models.ProtocolVersion
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.quivr.models.{Int128, Proposition}
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.box._
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.box.*
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, UnspentTransactionOutput}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object PrivateTestnet {
 

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/PublicTestnet.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/PublicTestnet.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.blockchain
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object PublicTestnet {
 

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/StakerInitializer.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/StakerInitializer.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.blockchain
 
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
 import org.plasmalabs.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.quivr.models._
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.box._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.quivr.models.*
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.box.*
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, UnspentTransactionOutput}
 
 /**

--- a/blockchain/src/main/scala/org/plasmalabs/blockchain/StakingInit.scala
+++ b/blockchain/src/main/scala/org/plasmalabs/blockchain/StakingInit.scala
@@ -1,29 +1,29 @@
 package org.plasmalabs.blockchain
 
-import cats._
+import cats.*
 import cats.data.OptionT
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.algebras.{ClockAlgebra, Stats}
 import org.plasmalabs.blockchain.algebras.NodeMetadataAlgebra
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models.{VrfConfig, _}
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.{VrfConfig, *}
 import org.plasmalabs.interpreters.CatsSecureStore
 import org.plasmalabs.minting.algebras.StakingAlgebra
-import org.plasmalabs.minting.interpreters._
-import org.plasmalabs.models.protocol.BigBangConstants._
+import org.plasmalabs.minting.interpreters.*
+import org.plasmalabs.models.protocol.BigBangConstants.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{LockAddress, TransactionId}
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/blockchain/src/test/scala/org/plasmalabs/blockchain/LocalChainSynchronizationTraversalSpec.scala
+++ b/blockchain/src/test/scala/org/plasmalabs/blockchain/LocalChainSynchronizationTraversalSpec.scala
@@ -6,8 +6,8 @@ import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.SynchronizationTraversalSteps.{Applied, Unapplied}
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 
 class LocalChainSynchronizationTraversalSpec extends CatsEffectSuite with ScalaCheckEffectSuite {

--- a/blockchain/src/test/scala/org/plasmalabs/blockchain/MempoolProtectedTest.scala
+++ b/blockchain/src/test/scala/org/plasmalabs/blockchain/MempoolProtectedTest.scala
@@ -2,22 +2,22 @@ package org.plasmalabs.blockchain
 
 import cats.data.Validated
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.algebras.Stats.Implicits.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig.Node.MempoolProtection
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models.{IoTransactionEx, MempoolGraph, RewardQuantities, _}
-import org.plasmalabs.models.ModelGenerators._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.{IoTransactionEx, MempoolGraph, RewardQuantities, *}
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.*
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitraryBlockId
-import org.plasmalabs.models.generators.consensus._
 import org.plasmalabs.networking.fsnetwork.TestHelper.arbitraryIoTransaction
 import org.plasmalabs.quivr.runtime.DynamicContext
 import org.plasmalabs.sdk.constants.NetworkConstants
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{Datum, TransactionId, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.TransactionAuthorizationError
 import org.plasmalabs.sdk.validation.algebras.{TransactionAuthorizationVerifier, TransactionCostCalculator}
 import org.scalacheck.Arbitrary

--- a/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
+++ b/blockchain/src/test/scala/org/plasmalabs/blockchain/StakerInitializersSpec.scala
@@ -2,15 +2,15 @@ package org.plasmalabs.blockchain
 
 import cats.effect.IO
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.blockchain.PrivateTestnet.{DefaultTotalStake, GroupPolicyEth, SeriesPolicyEth}
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalamock.munit.AsyncMockFactory
 
 import scala.concurrent.duration.FiniteDuration

--- a/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/scodecs/valuetypes/OptionCodec.scala
+++ b/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/scodecs/valuetypes/OptionCodec.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.codecs.bytes.scodecs.valuetypes
 
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.codecs.bytes.scodecs.valuetypes.Constants.byteSize
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, DecodeResult, Decoder, Encoder, Err, SizeBound}

--- a/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
+++ b/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/scodecs/valuetypes/ValuetypesCodecs.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.codecs.bytes.scodecs.valuetypes
 
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.ZigZagEncoder._
-import org.plasmalabs.codecs.bytes.scodecs.valuetypes.Constants._
-import org.plasmalabs.codecs.bytes.scodecs.valuetypes.Types._
+import org.plasmalabs.codecs.bytes.ZigZagEncoder.*
+import org.plasmalabs.codecs.bytes.scodecs.valuetypes.Constants.*
+import org.plasmalabs.codecs.bytes.scodecs.valuetypes.Types.*
 import scodec.bits.BitVector
-import scodec.interop.cats._
+import scodec.interop.cats.*
 import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
 
 trait ValuetypesCodecs {

--- a/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/typeclasses/Persistable.scala
+++ b/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/typeclasses/Persistable.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.codecs.bytes.typeclasses
 
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec}

--- a/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/typeclasses/Transmittable.scala
+++ b/byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/typeclasses/Transmittable.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.codecs.bytes.typeclasses
 
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec}

--- a/byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/CodecSpec.scala
+++ b/byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/CodecSpec.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.codecs.bytes
 
 import cats.Eq
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF
 import org.scalacheck.{Arbitrary, Gen}

--- a/cats-utils/src/main/scala/org/plasmalabs/catsutils/AbandonerPipe.scala
+++ b/cats-utils/src/main/scala/org/plasmalabs/catsutils/AbandonerPipe.scala
@@ -4,8 +4,8 @@ import cats.data.EitherT
 import cats.effect.Async
 import cats.effect.kernel.Sync
 import cats.effect.std.Queue
-import cats.implicits._
-import fs2._
+import cats.implicits.*
+import fs2.*
 
 object AbandonerPipe {
 

--- a/cats-utils/src/main/scala/org/plasmalabs/catsutils/DroppingTopic.scala
+++ b/cats-utils/src/main/scala/org/plasmalabs/catsutils/DroppingTopic.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.catsutils
 
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.concurrent.Topic
 
 object DroppingTopic {

--- a/cats-utils/src/main/scala/org/plasmalabs/catsutils/FOps.scala
+++ b/cats-utils/src/main/scala/org/plasmalabs/catsutils/FOps.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.catsutils
 
 import cats.Monad
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Clock}
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.language.implicitConversions
 
 trait FOps {

--- a/cats-utils/src/test/scala/org/plasmalabs/catsutils/FOpsSpec.scala
+++ b/cats-utils/src/test/scala/org/plasmalabs/catsutils/FOpsSpec.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.catsutils
 
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.Queue
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class FOpsSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 

--- a/common-application/src/main/scala/org/plasmalabs/common/application/IOBaseApp.scala
+++ b/common-application/src/main/scala/org/plasmalabs/common/application/IOBaseApp.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.common.application
 
 import cats.data.{Chain, EitherT, Nested, OptionT}
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import cats.kernel.Monoid
 import com.typesafe.config.{Config, ConfigFactory}
 import fs2.io.file.Files
@@ -11,7 +11,7 @@ import org.http4s.client.middleware.FollowRedirect
 import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import pureconfig._
+import pureconfig.*
 
 /**
  * Assists with constructing applications which use cats-effect  Initializes the runtime and configurations.

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/BlockHeightTree.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/BlockHeightTree.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.{Store, StoreReader}
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object BlockHeightTree {
 

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/CacheStore.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/CacheStore.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.kernel.Sync
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.plasmalabs.algebras.Store
 import scalacache.Entry

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/CatsSecureStore.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/CatsSecureStore.scala
@@ -3,14 +3,14 @@ package org.plasmalabs.interpreters
 import cats.data.Chain
 import cats.effect.std.Semaphore
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import org.plasmalabs.algebras.SecureStore
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /**
  * Interprets the SecureStore algebra using cats-effect and java NIO.

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/ContainsCacheStore.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/ContainsCacheStore.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.kernel.Sync
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.plasmalabs.algebras.Store
 import scalacache.Entry

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/FileStatsInterpreter.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/FileStatsInterpreter.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.interpreters
 
 import cats.Applicative
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.{Resource, Sync}
 import io.circe.Json
 import org.plasmalabs.algebras.Stats

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/KamonStatsInterpreter.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/KamonStatsInterpreter.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.interpreters
 
 import cats.Applicative
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.{Ref, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import io.circe.Json
 import kamon.Kamon
 import kamon.metric.Metric

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/MultiNodeRpc.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/MultiNodeRpc.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.interpreters
 import cats.Foldable
 import cats.effect.Async
 import cats.effect.std.{Random, SecureRandom}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.algebras.{NodeRpc, SynchronizationTraversalStep}
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/NodeRpcOps.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/NodeRpcOps.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.interpreters
 
 import cats.data.OptionT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
 import fs2.Stream
 import org.plasmalabs.algebras.{NodeRpc, SynchronizationTraversalSteps}
@@ -10,7 +10,7 @@ import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.node.models.{FullBlock, FullBlockBody}
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.language.implicitConversions
 
 object NodeRpcOps extends NodeRpcOps

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/NtpClockSkewer.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/NtpClockSkewer.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.interpreters
 
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
-import fs2._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
+import fs2.*
 import org.apache.commons.net.ntp.NTPUDPClient
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.net.InetAddress
-import scala.concurrent.duration._
-import scala.jdk.DurationConverters._
+import scala.concurrent.duration.*
+import scala.jdk.DurationConverters.*
 
 object NtpClockSkewer {
 

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/SchedulerClock.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/SchedulerClock.scala
@@ -3,13 +3,13 @@ package org.plasmalabs.interpreters
 import cats.Applicative
 import cats.effect.kernel.Async
 import cats.effect.{Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.ClockAlgebra
 import org.plasmalabs.models.{Epoch, Slot, Timestamp}
 
 import java.time.Instant
 import scala.collection.immutable.NumericRange
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object SchedulerClock {
 

--- a/common-interpreters/src/main/scala/org/plasmalabs/interpreters/TxIdToBlockIdTree.scala
+++ b/common-interpreters/src/main/scala/org/plasmalabs/interpreters/TxIdToBlockIdTree.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionId
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object TxIdToBlockIdTree {
   type State[F[_]] = Store[F, TransactionId, BlockId]

--- a/common-interpreters/src/test/scala/org/plasmalabs/interpreters/CacheStoreSpec.scala
+++ b/common-interpreters/src/test/scala/org/plasmalabs/interpreters/CacheStoreSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.CatsEffectSuite
 import org.plasmalabs.algebras.Store
 import org.scalamock.munit.AsyncMockFactory

--- a/common-interpreters/src/test/scala/org/plasmalabs/interpreters/CatsSecureStoreSpec.scala
+++ b/common-interpreters/src/test/scala/org/plasmalabs/interpreters/CatsSecureStoreSpec.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import fs2.io.{file => fs2file}
+import fs2.io.file as fs2file
 import munit.CatsEffectSuite
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
 

--- a/common-interpreters/src/test/scala/org/plasmalabs/interpreters/ContainsCacheStoreSpec.scala
+++ b/common-interpreters/src/test/scala/org/plasmalabs/interpreters/ContainsCacheStoreSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.interpreters
 
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.{Files, Path}
 import munit.CatsEffectSuite
 import org.plasmalabs.algebras.Store

--- a/config/src/main/scala/org/plasmalabs/config/ApplicationConfig.scala
+++ b/config/src/main/scala/org/plasmalabs/config/ApplicationConfig.scala
@@ -3,11 +3,11 @@ package org.plasmalabs.config
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
 import org.plasmalabs.models.Slot
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.proto.node.NodeConfig
 import org.plasmalabs.sdk.models.LockAddress
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 // $COVERAGE-OFF$
 case class ApplicationConfig(

--- a/consensus/src/main/scala/org/plasmalabs/consensus/Consensus.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/Consensus.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.consensus
 
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 
 trait Consensus[F[_]] {

--- a/consensus/src/main/scala/org/plasmalabs/consensus/algebras/ConsensusValidationStateAlgebra.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/algebras/ConsensusValidationStateAlgebra.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.consensus.algebras
 
 import cats.Monad
 import cats.data.OptionT
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.consensus.models.{ActiveStaker, BlockId, StakingAddress}
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
 trait ConsensusValidationStateAlgebra[F[_]] {
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/algebras/VersionInfoAlgebra.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/algebras/VersionInfoAlgebra.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.consensus.algebras
 
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 trait VersionInfoAlgebra[F[_]] {
   def addVersionStartEpoch(epoch:    Epoch, version: VersionId): F[Unit]

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderToBodyValidation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderToBodyValidation.scala
@@ -5,10 +5,10 @@ import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEq}
 import org.plasmalabs.consensus.algebras.BlockHeaderToBodyValidationAlgebra
 import org.plasmalabs.consensus.models.BlockHeaderToBodyValidationFailure
 import org.plasmalabs.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
 import org.plasmalabs.node.models.Block
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object BlockHeaderToBodyValidation {
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderValidation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderValidation.scala
@@ -1,26 +1,26 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.data._
+import cats.data.*
 import cats.effect.Resource
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
 import org.plasmalabs.algebras.ClockAlgebra.implicits.clockAsClockOps
 import org.plasmalabs.algebras.{ClockAlgebra, Store}
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData, SlotId, _}
-import org.plasmalabs.consensus.{thresholdEvidence, _}
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData, SlotId, *}
+import org.plasmalabs.consensus.{thresholdEvidence, *}
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
+import org.plasmalabs.typeclasses.implicits.*
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVersionValidation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVersionValidation.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.data._
+import cats.data.*
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.models.BlockHeaderValidationFailures._
+import org.plasmalabs.consensus.models.BlockHeaderValidationFailures.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockHeaderValidationFailure, BlockId}
 import org.plasmalabs.eventtree.EventSourcedState
 import org.plasmalabs.models.VersionId

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVotingValidation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVotingValidation.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.data._
+import cats.data.*
 import cats.effect.kernel.Async
-import cats.implicits._
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras._
-import org.plasmalabs.consensus.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
 import org.plasmalabs.consensus.models.BlockHeaderValidationFailures.{IncorrectVotedProposalId, IncorrectVotedVersionId}
 import org.plasmalabs.consensus.models.{BlockHeader, BlockHeaderValidationFailure, BlockId}

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ChainSelection.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ChainSelection.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats._
-import cats.data._
-import cats.effect._
-import cats.implicits._
+import cats.*
+import cats.data.*
+import cats.effect.*
+import cats.implicits.*
 import org.plasmalabs.algebras.Stats
 import org.plasmalabs.consensus.algebras.ChainSelectionAlgebra
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.consensus.rhoToRhoTestHash
 import org.plasmalabs.crypto.hash.Blake2b512
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ConsensusDataEventSourcedState.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ConsensusDataEventSourcedState.scala
@@ -2,15 +2,15 @@ package org.plasmalabs.consensus.interpreters
 
 import cats.MonadThrow
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
 import org.plasmalabs.consensus.models.{ActiveStaker, BlockId, StakingAddress}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * An EventSourcedState which operates on a `ConsensusData`.

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ConsensusValidationState.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/ConsensusValidationState.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.consensus.algebras.ConsensusValidationStateAlgebra
 import org.plasmalabs.consensus.models.{ActiveStaker, BlockId, StakingAddress}
 import org.plasmalabs.eventtree.EventSourcedState
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 object ConsensusValidationState {
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/CrossEpochEventSourceState.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/CrossEpochEventSourceState.scala
@@ -1,21 +1,21 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats._
+import cats.*
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras.StoreOps._
-import org.plasmalabs.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.algebras.StoreOps.*
 import org.plasmalabs.consensus.algebras.VersionInfoAlgebra
 import org.plasmalabs.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.{ProposalData, ProposalEventSourceStateType}
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object CrossEpochEventSourceState {

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EligibilityCache.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EligibilityCache.scala
@@ -1,14 +1,14 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.algebras.EligibilityCacheAlgebra
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.models.*
+import org.plasmalabs.typeclasses.implicits.*
 
 import scala.collection.immutable.SortedMap
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EpochBoundariesEventSourcedState.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EpochBoundariesEventSourcedState.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
-import org.plasmalabs.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * An EventSourcedState which operates on an `EpochBoundaries`.

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EtaCalculation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/EtaCalculation.scala
@@ -1,21 +1,21 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.data.NonEmptyChain
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import cats.{MonadThrow, Parallel}
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.protobuf.ByteString
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.algebras.{ClockAlgebra, Stats}
 import org.plasmalabs.consensus.algebras.EtaCalculationAlgebra
 import org.plasmalabs.consensus.models.{BlockId, EtaCalculationArgs, SlotData, SlotId}
 import org.plasmalabs.consensus.rhoToRhoNonceHash
 import org.plasmalabs.crypto.hash.{Blake2b256, Blake2b512}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.{Sized, _}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.{Sized, *}
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import scalacache.Entry

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/LeaderElectionValidation.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/LeaderElectionValidation.scala
@@ -1,15 +1,15 @@
 package org.plasmalabs.consensus.interpreters
 
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import org.plasmalabs.consensus.algebras.LeaderElectionValidationAlgebra
 import org.plasmalabs.consensus.models.VrfConfig
 import org.plasmalabs.consensus.rhoToRhoTestHash
 import org.plasmalabs.crypto.hash.Blake2b512
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.numerics.algebras.{Exp, Log1p}
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import scalacache.caffeine.CaffeineCache
 
 /**

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/LocalChain.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/LocalChain.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.data.{EitherT, NonEmptyChain, Validated}
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Sync
 import cats.effect.{Async, Ref, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.eventtree.EventSourcedState
-import org.plasmalabs.typeclasses.implicits._
-import org.typelevel.log4cats._
+import org.plasmalabs.typeclasses.implicits.*
+import org.typelevel.log4cats.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object LocalChain {

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/VersionInfo.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/VersionInfo.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
 import org.plasmalabs.consensus.algebras.VersionInfoAlgebra
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.typelevel.log4cats.Logger
 
 import scala.collection.mutable

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/VotingEventSourceState.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/VotingEventSourceState.scala
@@ -2,16 +2,16 @@ package org.plasmalabs.consensus.interpreters
 
 import cats.MonadThrow
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras.StoreOps._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.algebras.StoreOps.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
-import org.plasmalabs.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object VotingEventSourceState {

--- a/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/package.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/interpreters/package.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.consensus
 
 import org.plasmalabs.consensus.models.{BlockHeader, ProtocolVersion}
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 package object interpreters {
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/models/BlockHeaderValidationFailure.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/models/BlockHeaderValidationFailure.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.consensus.models
 
 import org.plasmalabs.crypto.models.SignatureKesProduct
-import org.plasmalabs.{models => legacyModels}
+import org.plasmalabs.models as legacyModels
 
 import legacyModels.Bytes
 import legacyModels.Eta

--- a/consensus/src/main/scala/org/plasmalabs/consensus/models/VrfArgument.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/models/VrfArgument.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.consensus.models
 
 import com.google.protobuf.ByteString
 import org.plasmalabs.codecs.bytes.typeclasses.Signable
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 case class VrfArgument(eta: Eta, slot: Slot)
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/models/package.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/models/package.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.consensus
 
 import com.google.protobuf.ByteString
-import org.plasmalabs.consensus.{models => consensusModels}
-import org.plasmalabs.crypto.{models => cryptoModels}
+import org.plasmalabs.consensus.models as consensusModels
+import org.plasmalabs.crypto.models as cryptoModels
 
 import scala.language.implicitConversions
 

--- a/consensus/src/main/scala/org/plasmalabs/consensus/package.scala
+++ b/consensus/src/main/scala/org/plasmalabs/consensus/package.scala
@@ -5,7 +5,7 @@ import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.models.{BlockHeader, SlotData, SlotId}
 import org.plasmalabs.crypto.hash.{Blake2b256, Blake2b512}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.{Bytes, UnsignedBlockHeader}
 
 package object consensus {

--- a/consensus/src/test/scala/org/plasmalabs/consensus/EphemeralSecureStore.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/EphemeralSecureStore.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.consensus
 
 import cats.data.Chain
-import cats.implicits._
+import cats.implicits.*
 import cats.{Defer, Monad}
 import org.plasmalabs.algebras.SecureStore
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 import org.plasmalabs.models.Bytes
 
 /**

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderValidationSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderValidationSpec.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.data.EitherT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import cats.{Monad, MonadThrow, Show}
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.{ClockAlgebra, Store}
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.models.{
   ActiveStaker,
   BlockHeaderValidationFailures,
@@ -18,22 +18,22 @@ import org.plasmalabs.consensus.models.{
   StakingAddress,
   VrfArgument,
   VrfConfig,
-  _
+  *
 }
 import org.plasmalabs.consensus.thresholdEvidence
 import org.plasmalabs.crypto.generation.mnemonic.Entropy
 import org.plasmalabs.crypto.hash.{Blake2b256, Blake2b512}
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
-import org.plasmalabs.crypto.signing.{Ed25519, _}
+import org.plasmalabs.crypto.signing.{Ed25519, *}
+import org.plasmalabs.models.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models._
 import org.plasmalabs.models.generators.common.ModelGenerators.genSizedStrictByteString
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
-import org.plasmalabs.models.utility._
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.numerics.interpreters.{ExpInterpreter, Log1pInterpreter}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVersionValidationTest.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVersionValidationTest.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.testInterpreters._
+import org.plasmalabs.algebras.testInterpreters.*
 import org.plasmalabs.algebras.{ClockAlgebra, Store}
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.models.BlockHeaderValidationFailures._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.consensus.models.BlockHeaderValidationFailures.*
 import org.plasmalabs.eventtree.EventSourcedState
+import org.plasmalabs.models.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVotingValidationTest.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/BlockHeaderVotingValidationTest.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.testInterpreters._
+import org.plasmalabs.algebras.testInterpreters.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.models.BlockHeaderValidationFailures._
-import org.plasmalabs.consensus.models.{BlockHeaderValidationFailure, _}
+import org.plasmalabs.consensus.models.BlockHeaderValidationFailures.*
+import org.plasmalabs.consensus.models.{BlockHeaderValidationFailure, *}
 import org.plasmalabs.eventtree.EventSourcedState
+import org.plasmalabs.models.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ChainSelectionSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ChainSelectionSpec.scala
@@ -1,18 +1,18 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.algebras.Stats.Implicits.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.consensus.rhoToRhoTestHash
 import org.plasmalabs.crypto.hash.Blake2b512
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.common.ModelGenerators._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.common.ModelGenerators.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.plasmalabs.models.utility.{Lengths, Sized}
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 import org.scalamock.munit.AsyncMockFactory

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ConsensusDataEventSourcedStateSpec.scala
@@ -2,21 +2,21 @@ package org.plasmalabs.consensus.interpreters
 
 import cats.Applicative
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.TestStore
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.box._
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.box.*
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 
 class ConsensusDataEventSourcedStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ConsensusValidationStateSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/ConsensusValidationStateSpec.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.consensus.interpreters.EpochBoundariesEventSourcedState.EpochBoundaries
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.eventtree.EventSourcedState
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.numerics.implicits.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EligibilityCacheSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EligibilityCacheSpec.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.algebras.EligibilityCacheAlgebra
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.models.utility.Lengths
 import org.scalamock.munit.AsyncMockFactory
 

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EpochBoundariesEventSourcedStateSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EpochBoundariesEventSourcedStateSpec.scala
@@ -3,16 +3,16 @@ package org.plasmalabs.consensus.interpreters
 import cats.Applicative
 import cats.data.Chain
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitrarySlotData
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 
 class EpochBoundariesEventSourcedStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EtaCalculationSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/EtaCalculationSpec.scala
@@ -1,23 +1,23 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.implicits.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.Stats.Implicits._
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData, SlotId, VrfArgument}
-import org.plasmalabs.consensus.{rhoToRhoNonceHash, _}
+import org.plasmalabs.consensus.{rhoToRhoNonceHash, *}
 import org.plasmalabs.crypto.hash.{Blake2b256, Blake2b512}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
-import org.plasmalabs.models.utility._
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 import org.scalacheck.Gen
 import org.scalamock.munit.AsyncMockFactory

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/LocalChainSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/LocalChainSpec.scala
@@ -4,21 +4,21 @@ import cats.Applicative
 import cats.data.{NonEmptyChain, Validated}
 import cats.effect.IO
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
 import org.plasmalabs.consensus.algebras.ChainSelectionAlgebra
 import org.plasmalabs.consensus.models.{BlockId, SlotData, SlotId}
 import org.plasmalabs.eventtree.EventSourcedState
-import org.plasmalabs.models.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.models.generators.common.ModelGenerators.genSizedStrictByteString
 import org.plasmalabs.models.generators.consensus.ModelGenerators.etaGen
 import org.plasmalabs.models.utility.Lengths
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class LocalChainSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/VersionInfoSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/VersionInfoSpec.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.TestStore
-import org.plasmalabs.models.{Epoch, _}
+import org.plasmalabs.models.{Epoch, *}
 import org.plasmalabs.sdk.generators.TransactionGenerator
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger

--- a/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/VotingEventSourceStateSpec.scala
+++ b/consensus/src/test/scala/org/plasmalabs/consensus/interpreters/VotingEventSourceStateSpec.scala
@@ -1,35 +1,35 @@
 package org.plasmalabs.consensus.interpreters
 
 import cats.effect.{Async, IO}
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.algebras.{ClockAlgebra, Store}
-import org.plasmalabs.codecs.bytes.tetra.ModelGenerators._
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.consensus._
+import org.plasmalabs.codecs.bytes.tetra.ModelGenerators.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.consensus.*
 import org.plasmalabs.consensus.algebras.VersionInfoAlgebra
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.models.{BlockHeader, BlockId, _}
+import org.plasmalabs.consensus.models.{BlockHeader, BlockId, *}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState
-import org.plasmalabs.ledger.interpreters.ProposalEventSourceState._
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models._
+import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.*
+import org.plasmalabs.models.*
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitraryHeader
 import org.plasmalabs.models.protocol.{ConfigConverter, ConfigGenesis}
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.sdk.generators.TransactionGenerator
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/event-tree/src/main/scala/org/plasmalabs/eventtree/EventSourcedState.scala
+++ b/event-tree/src/main/scala/org/plasmalabs/eventtree/EventSourcedState.scala
@@ -2,9 +2,9 @@ package org.plasmalabs.eventtree
 
 import cats.Eq
 import cats.data.Chain
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.Semaphore
-import cats.implicits._
+import cats.implicits.*
 
 /**
  * Derives/computes/retrieves the State at some eventId

--- a/event-tree/src/main/scala/org/plasmalabs/eventtree/ParentChildTree.scala
+++ b/event-tree/src/main/scala/org/plasmalabs/eventtree/ParentChildTree.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.eventtree
 
-import cats._
+import cats.*
 import cats.data.{NonEmptyChain, OptionT}
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 
 trait ParentChildTree[F[_], T] {
 

--- a/event-tree/src/test/scala/org/plasmalabs/eventtree/EventSourcedStateSpec.scala
+++ b/event-tree/src/test/scala/org/plasmalabs/eventtree/EventSourcedStateSpec.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.eventtree
 
 import cats.data.OptionT
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Eq, Functor, MonadThrow, Semigroupal, Show}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store

--- a/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/EthereumJsonRpc.scala
@@ -2,22 +2,22 @@ package org.plasmalabs.grpc
 
 import cats.data.OptionT
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.comcast.ip4s.{Host, Port}
 import fs2.io.net.Network
-import io.circe._
-import io.circe.syntax._
-import org.http4s._
-import org.http4s.circe.CirceEntityCodec._
-import org.http4s.circe._
+import io.circe.*
+import io.circe.syntax.*
+import org.http4s.*
+import org.http4s.circe.*
+import org.http4s.circe.CirceEntityCodec.*
 import org.http4s.dsl.Http4sDslBinCompat
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 import org.http4s.server.middleware.CORS
 import org.plasmalabs.blockchain.BlockchainCore
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.BlockHeader
-import org.plasmalabs.models.protocol.BigBangConstants._
+import org.plasmalabs.models.protocol.BigBangConstants.*
 import org.plasmalabs.typeclasses.implicits.showBlockId
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector

--- a/grpc/src/main/scala/org/plasmalabs/grpc/Grpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/Grpc.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.grpc
 
 import cats.effect.kernel.{Async, Resource}
-import fs2.grpc.syntax.all._
+import fs2.grpc.syntax.all.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.{Server, ServerServiceDefinition}

--- a/grpc/src/main/scala/org/plasmalabs/grpc/HealthCheckGrpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/HealthCheckGrpc.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.grpc
 
 import cats.effect.kernel.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
-import grpc.health.v1._
+import grpc.health.v1.*
 import io.grpc.ServerServiceDefinition
 import org.plasmalabs.algebras.HealthCheckAlgebra
 import org.plasmalabs.grpc.services.HealthCheckService

--- a/grpc/src/main/scala/org/plasmalabs/grpc/NodeGrpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/NodeGrpc.scala
@@ -2,17 +2,17 @@ package org.plasmalabs.grpc
 
 import cats.MonadThrow
 import cats.effect.kernel.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
-import fs2.grpc.syntax.all._
+import fs2.grpc.syntax.all.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.{Metadata, Server, ServerServiceDefinition}
-import org.plasmalabs.algebras.{NodeRpc, _}
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.algebras.{NodeRpc, *}
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.models.Epoch
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 import org.plasmalabs.proto.node.{EpochData, NodeConfig}
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction

--- a/grpc/src/main/scala/org/plasmalabs/grpc/RegTestGrpc.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/RegTestGrpc.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.grpc
 
 import cats.effect.kernel.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import io.grpc.Metadata
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.models.{ProposalId, VersionId}
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 
 object RegTestGrpc {
 

--- a/grpc/src/main/scala/org/plasmalabs/grpc/RpcServer.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/RpcServer.scala
@@ -2,12 +2,12 @@ package org.plasmalabs.grpc
 
 import cats.data.{EitherT, OptionT}
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import cats.{Monad, Show}
 import fs2.Stream
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.blockchain.{BlockchainCore, LocalChainSynchronizationTraversal}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
 import org.plasmalabs.models.Epoch
@@ -15,9 +15,9 @@ import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.proto.node.{EpochData, NodeConfig}
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.TransactionSyntaxError
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 

--- a/grpc/src/main/scala/org/plasmalabs/grpc/package.scala
+++ b/grpc/src/main/scala/org/plasmalabs/grpc/package.scala
@@ -2,8 +2,8 @@ package org.plasmalabs
 
 import cats.ApplicativeThrow
 import cats.effect.{Resource, Sync}
-import cats.implicits._
-import fs2.grpc.syntax.all._
+import cats.implicits.*
+import fs2.grpc.syntax.all.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.{ManagedChannel, Status, StatusException}
 import scalapb.validate.FieldValidationException

--- a/grpc/src/test/scala/org/plasmalabs/grpc/NodeGrpcSpec.scala
+++ b/grpc/src/test/scala/org/plasmalabs/grpc/NodeGrpcSpec.scala
@@ -2,21 +2,21 @@ package org.plasmalabs.grpc
 
 import cats.Applicative
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import io.grpc.Metadata
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.NodeRpc
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.generators.node.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.generators.node.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 import org.plasmalabs.proto.node.{EpochData, NodeConfig}
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/grpc/src/test/scala/org/plasmalabs/grpc/NodeRpcServerSpec.scala
+++ b/grpc/src/test/scala/org/plasmalabs/grpc/NodeRpcServerSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.grpc
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.{ClockAlgebra, ProtocolConfigurationAlgebra, Store}
@@ -13,7 +13,7 @@ import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.ledger.Ledger
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.proto.node.{EpochData, NodeConfig}
 import org.plasmalabs.sdk.models.TransactionId

--- a/indexer/src/main/scala/org/plasmalabs/indexer/Indexer.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/Indexer.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.indexer
 
-import cats.effect._
+import cats.effect.*
 import fs2.io.file.Files
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.grpc.NodeGrpc
-import org.plasmalabs.indexer.algebras._
-import org.plasmalabs.indexer.interpreter.{GraphReplicationStatus, _}
+import org.plasmalabs.indexer.algebras.*
+import org.plasmalabs.indexer.interpreter.{GraphReplicationStatus, *}
 import org.plasmalabs.indexer.orientDb.{OrientDBFactory, OrientThread}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -13,8 +13,8 @@ import org.plasmalabs.interpreters.KamonStatsRef
 import org.plasmalabs.node.services.NodeRpcFs2Grpc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import pureconfig.generic.derivation.default._
-import pureconfig.{ConfigSource, _}
+import pureconfig.generic.derivation.default.*
+import pureconfig.{ConfigSource, *}
 
 import scala.concurrent.duration.Duration
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerBlockService.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerBlockService.scala
@@ -2,13 +2,13 @@ package org.plasmalabs.indexer
 
 import cats.data.EitherT
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.Metadata
 import org.plasmalabs.indexer.algebras.{BlockFetcherAlgebra, GraphReplicationStatusAlgebra}
 import org.plasmalabs.indexer.model.GEs
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 import org.plasmalabs.node.models.FullBlock
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 class GrpcBlockService[F[_]: Async](
   blockFetcher:     BlockFetcherAlgebra[F],

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerGrpc.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerGrpc.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.indexer
 
 import cats.effect.kernel.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Eval, Now}
-import fs2.grpc.syntax.all._
+import fs2.grpc.syntax.all.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.{Metadata, ServerServiceDefinition}
 import org.plasmalabs.algebras.IndexerRpc
@@ -14,7 +14,7 @@ import org.plasmalabs.indexer.algebras.{
   TransactionFetcherAlgebra,
   VertexFetcherAlgebra
 }
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 
 object IndexerGrpc {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerHealthCheck.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerHealthCheck.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.indexer
 
 import cats.MonadThrow
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Ref, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import fs2.concurrent.SignallingRef
 import grpc.health.v1.{HealthCheckRequest, HealthCheckResponse, ServingStatus}
 import io.grpc.{Status, StatusException}
 import org.plasmalabs.algebras.HealthCheckAlgebra
 import org.plasmalabs.models.ServiceStatus
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * HealthCheck

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerNetworkMetricsService.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerNetworkMetricsService.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.effect.kernel.Async
 import io.grpc.Metadata
 import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 
 class GrpcNetworkMetricsService[F[_]: Async](vertexFetcher: VertexFetcherAlgebra[F])
     extends NetworkMetricsServiceFs2Grpc[F, Metadata] {

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerTokenService.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerTokenService.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.effect.kernel.Async
 import io.grpc.Metadata
 import org.plasmalabs.indexer.algebras.TokenFetcherAlgebra
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 
 class GrpcTokenService[F[_]: Async](
   tokenFetcherAlgebra: TokenFetcherAlgebra[F]

--- a/indexer/src/main/scala/org/plasmalabs/indexer/NodeRpcProxy.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/NodeRpcProxy.scala
@@ -2,10 +2,10 @@ package org.plasmalabs.indexer
 
 import cats.effect.Async
 import cats.effect.kernel.Resource
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.Metadata
 import org.plasmalabs.grpc.makeChannel
-import org.plasmalabs.node.services._
+import org.plasmalabs.node.services.*
 
 class NodeRpcProxy[F[_], Ctx](client: NodeRpcFs2Grpc[F, Ctx]) extends NodeRpcFs2Grpc[F, Ctx] {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/Replicator.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/Replicator.scala
@@ -1,15 +1,15 @@
 package org.plasmalabs.indexer
 
-import cats.data._
+import cats.data.*
 import cats.effect.Async
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.{Outcome, Resource}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.{Stats, SynchronizationTraversalStep, SynchronizationTraversalSteps}
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.indexer.services.BlockData
-import org.plasmalabs.interpreters.NodeRpcOps._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.interpreters.NodeRpcOps.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphBlockFetcher.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphBlockFetcher.scala
@@ -3,13 +3,13 @@ package org.plasmalabs.indexer.interpreter
 import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.indexer.algebras.{BlockFetcherAlgebra, VertexFetcherAlgebra}
 import org.plasmalabs.indexer.model.GE
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
 import org.plasmalabs.indexer.services.BlockData
 import org.plasmalabs.node.models.{BlockBody, FullBlockBody}
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphBlockUpdater.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphBlockUpdater.scala
@@ -1,28 +1,28 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.data.EitherT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import com.orientechnologies.orient.core.sql.OCommandSQL
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.{OrientDynaElementIterable, OrientGraph}
 import fs2.Stream
-import org.plasmalabs.indexer.algebras._
+import org.plasmalabs.indexer.algebras.*
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits._
-import org.plasmalabs.indexer.orientDb.instances._
-import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances._
+import org.plasmalabs.indexer.orientDb.instances.*
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits.*
+import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances.*
 import org.plasmalabs.indexer.services.{BlockData, Txo, TxoState}
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionOutputAddress
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 object GraphBlockUpdater {

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphReplicationStatus.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphReplicationStatus.scala
@@ -3,19 +3,19 @@ package org.plasmalabs.indexer.interpreter
 import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import fs2.Stream
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.indexer.algebras.{GraphReplicationStatusAlgebra, NodeBlockFetcherAlgebra, VertexFetcherAlgebra}
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
 import org.plasmalabs.typeclasses.implicits.showBlockId
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object GraphReplicationStatus {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphTokenFetcher.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphTokenFetcher.scala
@@ -5,8 +5,8 @@ import cats.effect.Resource
 import cats.effect.kernel.Async
 import org.plasmalabs.indexer.algebras.{TokenFetcherAlgebra, VertexFetcherAlgebra}
 import org.plasmalabs.indexer.model.GE
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
+import org.plasmalabs.sdk.models.*
 
 object GraphTokenFetcher {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphTransactionFetcher.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphTransactionFetcher.scala
@@ -3,15 +3,15 @@ package org.plasmalabs.indexer.interpreter
 import cats.data.EitherT
 import cats.effect.Resource
 import cats.effect.kernel.Async
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.indexer.algebras.{TransactionFetcherAlgebra, VertexFetcherAlgebra}
 import org.plasmalabs.indexer.model.GE
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
 import org.plasmalabs.indexer.orientDb.instances.{SchemaBlockHeader, VertexSchemaInstances}
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{LockAddress, TransactionId}
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcher.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcher.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.Resource
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.sql.OCommandSQL
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
 import com.tinkerpop.blueprints.Vertex
@@ -10,15 +10,15 @@ import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
+import org.plasmalabs.indexer.orientDb.instances.*
 import org.plasmalabs.indexer.orientDb.instances.SchemaIoTransaction.Field
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
-import org.plasmalabs.indexer.orientDb.instances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
 import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances
-import org.plasmalabs.indexer.services._
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.indexer.services.*
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.syntax.transactionIdAsIdSyntaxOps
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 object GraphVertexFetcher {

--- a/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/NodeBlockFetcher.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/interpreter/NodeBlockFetcher.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.data.{EitherT, OptionT}
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.algebras.NodeRpc
 import org.plasmalabs.consensus.models.BlockId
@@ -16,7 +16,7 @@ import org.typelevel.log4cats.Logger
 
 import scala.collection.immutable.ListSet
 
-import EitherT._
+import EitherT.*
 
 object NodeBlockFetcher {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/model/GE.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/model/GE.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.indexer.model
 
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.sdk.models.TransactionId
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 import scala.collection.immutable.ListSet
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/OrientDBFactory.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/OrientDBFactory.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.indexer.orientDb
 
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.sql.OCommandSQL
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactory
 import fs2.io.file.{Files, Path}

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/OrientDBMetadataFactory.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/OrientDBMetadataFactory.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.indexer.orientDb
 
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal
 import com.orientechnologies.orient.core.metadata.schema.{OClass, OType}
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactory
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
-import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
+import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances.*
 import org.plasmalabs.indexer.orientDb.schema.{EdgeSchema, VertexSchema}
 import org.typelevel.log4cats.Logger
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockBody.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockBody.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.indexer.orientDb.instances
 
 import com.orientechnologies.orient.core.metadata.schema.OType
 import org.plasmalabs.indexer.orientDb.schema.OIndexable.Instances
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, VertexSchema}
 import org.plasmalabs.node.models.BlockBody
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockHeader.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockHeader.scala
@@ -3,9 +3,9 @@ package org.plasmalabs.indexer.orientDb.instances
 import com.google.protobuf.ByteString
 import org.plasmalabs.codecs.bytes.tetra.TetraScodecCodecs
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.indexer.orientDb.schema.OIndexable.Instances
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 
 object SchemaBlockHeader {

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaGroupPolicy.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaGroupPolicy.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.orientDb.instances
 
 import com.google.protobuf.ByteString
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import org.plasmalabs.sdk.models.{GroupPolicy, SeriesId, TransactionOutputAddress}
 import org.plasmalabs.sdk.syntax.groupPolicyAsGroupPolicySyntaxOps

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaIoTransaction.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaIoTransaction.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.indexer.orientDb.instances
 
 import com.orientechnologies.orient.core.metadata.schema.OType
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import org.plasmalabs.sdk.common.ContainsImmutable.instances.ioTransactionImmutable
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
 object SchemaIoTransaction {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaLockAddress.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaLockAddress.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import org.plasmalabs.sdk.codecs.AddressCodecs
 import org.plasmalabs.sdk.models.{LockAddress, LockId}

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaSeriesPolicy.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaSeriesPolicy.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.orientDb.instances
 
 import com.google.protobuf.struct.Struct
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import org.plasmalabs.sdk.models.box.{FungibilityType, QuantityDescriptorType}
 import org.plasmalabs.sdk.models.{SeriesPolicy, TransactionOutputAddress}

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaTxo.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/SchemaTxo.scala
@@ -2,14 +2,14 @@ package org.plasmalabs.indexer.orientDb.instances
 
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.tinkerpop.blueprints.Vertex
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.schema.{GraphDataEncoder, OIndexable, VertexSchema}
 import org.plasmalabs.indexer.services.{Txo, TxoState}
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
 import org.plasmalabs.sdk.models.{TransactionInputAddress, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
-import VertexSchemaInstances.instances._
+import VertexSchemaInstances.instances.*
 
 object SchemaTxo {
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/VertexSchemaInstances.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/orientDb/instances/VertexSchemaInstances.scala
@@ -5,14 +5,14 @@ import com.tinkerpop.blueprints.impls.orient.{OrientDynaElementIterable, OrientG
 import com.tinkerpop.blueprints.{Direction, Vertex}
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.models.BlockHeader
-import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances._
+import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances.*
 import org.plasmalabs.indexer.orientDb.schema.VertexSchema
 import org.plasmalabs.indexer.services.Txo
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 
 /**

--- a/indexer/src/test/scala/org/plasmalabs/indexer/DbFixtureUtil.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/DbFixtureUtil.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.indexer
 
 import cats.effect.{IO, Resource, SyncIO}
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.db.{ODatabaseType, OrientDB, OrientDBConfigBuilder}
 import com.tinkerpop.blueprints.impls.orient.OrientGraphFactoryV2
 import munit.{CatsEffectSuite, FunSuite, TestOptions}
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.*
 import org.plasmalabs.indexer.orientDb.{OrientDBMetadataFactory, OrientThread}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/indexer/src/test/scala/org/plasmalabs/indexer/GrpcBlockServiceTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/GrpcBlockServiceTest.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.indexer
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.{Metadata, StatusException}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.indexer.algebras.{BlockFetcherAlgebra, GraphReplicationStatusAlgebra}
 import org.plasmalabs.indexer.model.{GE, GEs}
-import org.plasmalabs.indexer.services._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.generators.node.ModelGenerators._
-import org.plasmalabs.node.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.indexer.services.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.generators.node.ModelGenerators.*
+import org.plasmalabs.node.models.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/indexer/src/test/scala/org/plasmalabs/indexer/GrpcNetworkMetricsServiceTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/GrpcNetworkMetricsServiceTest.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.indexer
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.{Metadata, StatusException}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 import org.scalamock.munit.AsyncMockFactory
 
 class GrpcNetworkMetricsServiceTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/indexer/src/test/scala/org/plasmalabs/indexer/GrpcTokenServiceTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/GrpcTokenServiceTest.scala
@@ -1,14 +1,14 @@
 package org.plasmalabs.indexer
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.{Metadata, StatusException}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.algebras.TokenFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
-import org.plasmalabs.indexer.services._
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.indexer.services.*
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/indexer/src/test/scala/org/plasmalabs/indexer/GrpcTransactionServiceTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/GrpcTransactionServiceTest.scala
@@ -1,18 +1,18 @@
 package org.plasmalabs.indexer
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import io.grpc.{Metadata, StatusException}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.algebras.TransactionFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
-import org.plasmalabs.indexer.services._
+import org.plasmalabs.indexer.services.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
 import org.plasmalabs.sdk.models.{LockAddress, TransactionId, TransactionOutputAddress}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphBlockFetcherTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphBlockFetcherTest.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
@@ -9,7 +9,7 @@ import org.plasmalabs.consensus.models.BlockHeader
 import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphBlockUpdaterTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphBlockUpdaterTest.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.{OrientEdge, OrientGraph, OrientVertex}
 import fs2.Stream
@@ -11,7 +11,7 @@ import org.plasmalabs.indexer.algebras.{BlockFetcherAlgebra, NodeBlockFetcherAlg
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
 import org.plasmalabs.indexer.services.BlockData
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
@@ -19,7 +19,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.lang
 import scala.annotation.nowarn
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class GraphBlockUpdaterTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphReplicationStatusTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphReplicationStatusTest.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -11,7 +11,7 @@ import org.plasmalabs.indexer.algebras.{NodeBlockFetcherAlgebra, VertexFetcherAl
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
 import org.plasmalabs.indexer.orientDb.instances.SchemaBlockHeader
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.typeclasses.implicits.showBlockId
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphTokenFetcherTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphTokenFetcherTest.scala
@@ -1,14 +1,14 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.instances.{SchemaGroupPolicy, SchemaSeriesPolicy}
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models.{GroupId, SeriesId, TransactionOutputAddress, _}
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.{GroupId, SeriesId, TransactionOutputAddress, *}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphTransactionFetcherTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphTransactionFetcherTest.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.indexer.interpreter
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.tinkerpop.blueprints.Vertex
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
@@ -11,9 +11,9 @@ import org.plasmalabs.indexer.algebras.VertexFetcherAlgebra
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
 import org.plasmalabs.indexer.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction, SchemaTxo}
-import org.plasmalabs.indexer.services._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.indexer.services.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{LockAddress, TransactionId, TransactionInputAddress, TransactionOutputAddress}
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcherExceptionTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcherExceptionTest.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.{IO, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.command.OCommandRequest
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx
@@ -10,8 +10,8 @@ import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.models.BlockHeader
 import org.plasmalabs.indexer.model.{GE, GEs}
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.{LockAddress, TransactionOutputAddress}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcherTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/GraphVertexFetcherTest.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.data.EitherT
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.id.ORecordId
 import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.blueprints.impls.orient.OrientVertex
@@ -10,14 +10,14 @@ import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.indexer.DbFixtureUtil
 import org.plasmalabs.indexer.model.GE
 import org.plasmalabs.indexer.orientDb.OrientThread
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits.*
 import org.plasmalabs.indexer.orientDb.instances.{SchemaBlockHeader, SchemaIoTransaction}
 import org.plasmalabs.indexer.services.{BlockStats, BlockchainSizeStats, Txo, TxoState, TxoStats}
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGenerator}
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGenerator
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.syntax.{
   groupPolicyAsGroupPolicySyntaxOps,
   ioTransactionAsTransactionSyntaxOps,

--- a/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/NodeBlockFetcherTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/interpreter/NodeBlockFetcherTest.scala
@@ -1,19 +1,19 @@
 package org.plasmalabs.indexer.interpreter
 
 import cats.effect.IO
-import cats.implicits._
-import fs2._
+import cats.implicits.*
+import fs2.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.NodeRpc
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
-import org.plasmalabs.indexer.model.GEs._
+import org.plasmalabs.indexer.model.GEs.*
 import org.plasmalabs.indexer.services.BlockData
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.{BlockBody, FullBlockBody}
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/GraphBlockUpdaterFixtureTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/GraphBlockUpdaterFixtureTest.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.indexer.orientDb
 
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.consensus.models.BlockHeader
 import org.plasmalabs.indexer.DbFixtureUtil
 import org.plasmalabs.indexer.algebras.{BlockFetcherAlgebra, NodeBlockFetcherAlgebra}
 import org.plasmalabs.indexer.interpreter.GraphBlockUpdater
-import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits._
-import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances._
+import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.implicits.*
+import org.plasmalabs.indexer.orientDb.schema.EdgeSchemaInstances.*
 import org.plasmalabs.indexer.services.BlockData
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.generators.node.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.generators.node.ModelGenerators.*
 import org.plasmalabs.node.models.FullBlockBody
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockBodyTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockBodyTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
@@ -10,7 +10,7 @@ import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances
 import org.plasmalabs.node.models.BlockBody
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaBlockBodyTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockHeaderTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaBlockHeaderTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
@@ -12,7 +12,7 @@ import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaBlockHeaderTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaGroupPolicyTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaGroupPolicyTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
@@ -9,12 +9,12 @@ import org.plasmalabs.indexer.orientDb.instances.SchemaGroupPolicy.Field
 import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.groupPolicySchema
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGenerator}
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGenerator
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaGroupPolicyTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaIoTransactionTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaIoTransactionTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import com.tinkerpop.blueprints.impls.orient.OrientVertex
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -13,11 +13,11 @@ import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances
 }
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGenerator}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGenerator
+import org.plasmalabs.sdk.syntax.*
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaIoTransactionTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaLockAddressTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaLockAddressTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
@@ -9,11 +9,11 @@ import org.plasmalabs.indexer.orientDb.instances.SchemaLockAddress.Field
 import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.lockAddressSchema
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.sdk.codecs.AddressCodecs
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGens}
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGens
 import org.plasmalabs.sdk.models.LockAddress
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaLockAddressTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaSeriesPolicyTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaSeriesPolicyTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
@@ -9,12 +9,12 @@ import org.plasmalabs.indexer.orientDb.instances.SchemaSeriesPolicy.Field
 import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances.seriesPolicySchema
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGenerator}
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGenerator
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.syntax.seriesPolicyAsSeriesPolicySyntaxOps
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaSeriesPolicyTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaTxoTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/instances/SchemaTxoTest.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.indexer.orientDb.instances
 
-import cats.implicits._
+import cats.implicits.*
 import com.orientechnologies.orient.core.metadata.schema.OType
 import munit.{CatsEffectFunFixtures, CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
@@ -9,10 +9,10 @@ import org.plasmalabs.indexer.orientDb.instances.VertexSchemaInstances.instances
 import org.plasmalabs.indexer.orientDb.{OrientDBMetadataFactory, OrientThread}
 import org.plasmalabs.indexer.services.{Txo, TxoState}
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.sdk.generators.{ModelGenerators => BramblGens}
+import org.plasmalabs.sdk.generators.ModelGenerators as BramblGens
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class SchemaTxoTest
     extends CatsEffectSuite

--- a/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/schema/VertexSchemaTest.scala
+++ b/indexer/src/test/scala/org/plasmalabs/indexer/orientDb/schema/VertexSchemaTest.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.indexer.orientDb.schema
 
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.indexer.DbFixtureUtil
-import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances._
+import org.plasmalabs.indexer.orientDb.schema.OTyped.Instances.*
 import org.plasmalabs.indexer.orientDb.{OrientDBMetadataFactory, OrientThread}
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class VertexSchemaTest extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory with DbFixtureUtil {
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/Ledger.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/Ledger.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.ledger
 
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.sdk.validation.algebras._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.sdk.validation.algebras.*
 
 trait Ledger[F[_]] {
   def transactionSyntaxValidation: TransactionSyntaxVerifier[F]

--- a/ledger/src/main/scala/org/plasmalabs/ledger/algebras/BodyProposalValidationAlgebra.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/algebras/BodyProposalValidationAlgebra.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.ledger.algebras
 
 import org.plasmalabs.algebras.ContextualValidationAlgebra
-import org.plasmalabs.ledger.models._
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.node.models.BlockBody
 
 trait BodyProposalValidationAlgebra[F[_]]

--- a/ledger/src/main/scala/org/plasmalabs/ledger/implicits/LedgerShowInstances.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/implicits/LedgerShowInstances.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.ledger.implicits
 
 import cats.Show
-import cats.implicits._
-import org.plasmalabs.ledger.models._
+import cats.implicits.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.quivr.runtime.QuivrRuntimeError
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.{TransactionAuthorizationError, TransactionSyntaxError}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 trait LedgerShowInstances {
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/AugmentedBoxState.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/AugmentedBoxState.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.ledger.algebras.BoxStateAlgebra
 import org.plasmalabs.sdk.models.TransactionOutputAddress
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
 object AugmentedBoxState {
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodyAuthorizationValidation.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodyAuthorizationValidation.scala
@@ -2,9 +2,9 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.ValidatedNec
 import cats.effect.Sync
-import cats.implicits._
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
+import cats.implicits.*
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.quivr.runtime.DynamicContext
 import org.plasmalabs.sdk.models.transaction.IoTransaction

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodyProposalValidation.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodyProposalValidation.scala
@@ -2,20 +2,20 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.ledger.algebras.BodyProposalValidationAlgebra
-import org.plasmalabs.ledger.interpreters.ProposalEventSourceState._
-import org.plasmalabs.ledger.models.BodySemanticErrors._
-import org.plasmalabs.ledger.models._
-import org.plasmalabs.models.{Epoch, _}
+import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.*
+import org.plasmalabs.ledger.models.*
+import org.plasmalabs.ledger.models.BodySemanticErrors.*
+import org.plasmalabs.models.{Epoch, *}
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object BodyProposalValidation {

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodySemanticValidation.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodySemanticValidation.scala
@@ -2,9 +2,9 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.{EitherT, NonEmptyChain, OptionT, Validated, ValidatedNec}
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
+import cats.implicits.*
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodySyntaxValidation.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BodySyntaxValidation.scala
@@ -2,17 +2,17 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.{EitherT, NonEmptySet, ValidatedNec}
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import cats.{Foldable, Order, Parallel}
 import com.google.protobuf.ByteString
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{TransactionId, TransactionOutputAddress}
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 import scala.collection.immutable.SortedSet
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BoxState.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/BoxState.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.{NonEmptySet, OptionT}
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.consensus.models.BlockId
@@ -11,8 +11,8 @@ import org.plasmalabs.ledger.algebras.BoxStateAlgebra
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{TransactionId, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 
 import scala.collection.immutable.SortedSet
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/Mempool.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/Mempool.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.data.EitherT
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.{ClockAlgebra, Stats}
 import org.plasmalabs.consensus.models.BlockId
@@ -15,7 +15,7 @@ import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object Mempool {
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/ProposalEventSourceState.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/ProposalEventSourceState.scala
@@ -1,21 +1,21 @@
 package org.plasmalabs.ledger.interpreters
 
-import cats._
+import cats.*
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras.StoreOps._
-import org.plasmalabs.algebras._
+import cats.implicits.*
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.algebras.StoreOps.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
-import org.plasmalabs.models._
-import org.plasmalabs.models.protocol.BigBangConstants._
-import org.plasmalabs.node.models._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.protocol.BigBangConstants.*
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/QuivrContext.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/QuivrContext.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.consensus.models.BlockHeader
 import org.plasmalabs.models.Slot
 import org.plasmalabs.quivr.runtime.DynamicContext
 import org.plasmalabs.sdk.Context
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 
 object QuivrContext {

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/RegistrationAccumulator.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/RegistrationAccumulator.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.MonadThrow
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
 import org.plasmalabs.eventtree.{EventSourcedState, ParentChildTree}
@@ -11,7 +11,7 @@ import org.plasmalabs.ledger.algebras.RegistrationAccumulatorAlgebra
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 /**
  * A RegistrationAccumulatorAlgebra interpreter which uses an EventSourcedState to track a set of Staking Addresses.

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/TransactionRewardCalculator.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/TransactionRewardCalculator.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.ledger.interpreters
 
-import cats.effect._
+import cats.effect.*
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.ledger.models.{AssetId, RewardQuantities}
 import org.plasmalabs.sdk.models.box.Value

--- a/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/TransactionSemanticValidation.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/interpreters/TransactionSemanticValidation.scala
@@ -2,16 +2,16 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.Monad
 import cats.data.{EitherT, NonEmptyChain, OptionT, Validated, ValidatedNec}
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import org.plasmalabs.algebras.ContextlessValidationAlgebra
 import org.plasmalabs.consensus.models.BlockId
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
-import org.plasmalabs.models._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
+import org.plasmalabs.models.*
 import org.plasmalabs.sdk.common.ContainsEvidence
 import org.plasmalabs.sdk.common.ContainsEvidence.blake2bEvidenceFromImmutable
-import org.plasmalabs.sdk.common.ContainsImmutable.instances._
+import org.plasmalabs.sdk.common.ContainsImmutable.instances.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput}

--- a/ledger/src/main/scala/org/plasmalabs/ledger/models/MempoolGraph.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/models/MempoolGraph.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.ledger.models
 
 import cats.data.NonEmptySet
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
 
 /**

--- a/ledger/src/main/scala/org/plasmalabs/ledger/models/RewardQuantities.scala
+++ b/ledger/src/main/scala/org/plasmalabs/ledger/models/RewardQuantities.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.ledger.models
 
-import cats.implicits._
+import cats.implicits.*
 import cats.{Monoid, Show}
 import org.plasmalabs.models.Bytes
 import org.plasmalabs.sdk.models.box.{FungibilityType, QuantityDescriptorType}
 import org.plasmalabs.sdk.models.{GroupId, SeriesId}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 case class RewardQuantities(
   lvl:    BigInt = BigInt(0),

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/AugmentedBoxStateSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/AugmentedBoxStateSpec.scala
@@ -2,19 +2,19 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.NonEmptySet
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 
 class AugmentedBoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodyProposalValidationTest.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodyProposalValidationTest.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.ValidatedNec
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
 import org.plasmalabs.algebras.testInterpreters.TestStore
@@ -10,20 +10,20 @@ import org.plasmalabs.codecs.bytes.tetra.ModelGenerators.arbitraryTxsAndBlock
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.EventSourcedState
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.ProposalData
-import org.plasmalabs.ledger.models._
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.ledger.models.*
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.models.protocol.RatioCodec.ratioToProtoRatio
 import org.plasmalabs.models.protocol.{ConfigConverter, ConfigGenesis}
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.models.{Epoch, ProposalConfig, ProposalId, Slot, Timestamp, emptyVersionId, proposalDelta}
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodySemanticValidationSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodySemanticValidationSpec.scala
@@ -1,21 +1,21 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
 import org.plasmalabs.ledger.algebras.{RegistrationAccumulatorAlgebra, TransactionSemanticValidationAlgebra}
-import org.plasmalabs.ledger.models._
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.ledger.models.*
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.{Lock, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, LockAddress, TransactionId}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodySyntaxValidationSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BodySyntaxValidationSpec.scala
@@ -1,20 +1,20 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.ledger.models.{AssetId, BodySyntaxErrors, RewardQuantities}
-import org.plasmalabs.models.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.{FungibilityType, Lock, QuantityDescriptorType, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{GroupId, LockAddress, SeriesId, TransactionId}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.TransactionSyntaxError
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
 import org.scalacheck.effect.PropF

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BoxStateSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/BoxStateSpec.scala
@@ -2,19 +2,19 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.data.NonEmptySet
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 
 class BoxStateSpec extends CatsEffectSuite with ScalaCheckEffectSuite {

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/MempoolSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/MempoolSpec.scala
@@ -2,30 +2,30 @@ package org.plasmalabs.ledger.interpreters
 
 import cats.Applicative
 import cats.data.NonEmptyChain
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.ledger.models.RewardQuantities
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.TransactionId
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.effect.PropF
 import org.scalacheck.{Gen, Test}
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class MempoolSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/RegistrationAccumulatorSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/RegistrationAccumulatorSpec.scala
@@ -1,21 +1,21 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.sdk.constants.NetworkConstants
 import org.plasmalabs.sdk.models.box.{Attestation, Lock, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, LockAddress}
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 
 class RegistrationAccumulatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/TransactionRewardCalculatorSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/TransactionRewardCalculatorSpec.scala
@@ -1,16 +1,16 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.ledger.models.AssetId
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.numerics.implicits.intAsInt128
 import org.plasmalabs.quivr.models.Int128
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.{Attestation, FungibilityType, QuantityDescriptorType, Value}
-import org.plasmalabs.sdk.models.transaction._
+import org.plasmalabs.sdk.models.transaction.*
 
 class TransactionRewardCalculatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 

--- a/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/TransactionSemanticValidationSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/interpreters/TransactionSemanticValidationSpec.scala
@@ -1,18 +1,18 @@
 package org.plasmalabs.ledger.interpreters
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.consensus.models.BlockId
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 

--- a/ledger/src/test/scala/org/plasmalabs/ledger/models/MempoolGraphSpec.scala
+++ b/ledger/src/test/scala/org/plasmalabs/ledger/models/MempoolGraphSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.ledger.models
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
@@ -9,7 +9,7 @@ import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.models.box.{Attestation, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, LockAddress, LockId, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
 import org.scalamock.munit.AsyncMockFactory
 

--- a/level-db-store/src/main/scala/org/plasmalabs/db/leveldb/LevelDbStore.scala
+++ b/level-db-store/src/main/scala/org/plasmalabs/db/leveldb/LevelDbStore.scala
@@ -2,15 +2,15 @@ package org.plasmalabs.db.leveldb
 
 import cats.Applicative
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import fs2.io.file._
-import org.iq80.leveldb.{Logger => _, _}
+import fs2.io.file.*
+import org.iq80.leveldb.{Logger as _, *}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 import java.util.InputMismatchException

--- a/level-db-store/src/test/scala/org/plasmalabs/db/leveldb/LevelDbStoreSpec.scala
+++ b/level-db-store/src/test/scala/org/plasmalabs/db/leveldb/LevelDbStoreSpec.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.db.leveldb
 
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.{Files, Path}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.testInterpreters.NoOpLogger
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import scodec.{Codec, codecs}
 

--- a/minting/src/main/scala/org/plasmalabs/minting/algebras/StakingAlgebra.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/algebras/StakingAlgebra.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.minting.algebras
 
 import org.plasmalabs.consensus.models.{BlockHeader, SlotId, StakingAddress}
 import org.plasmalabs.minting.models.VrfHit
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.sdk.models.LockAddress
 
 /**

--- a/minting/src/main/scala/org/plasmalabs/minting/algebras/VrfCalculatorAlgebra.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/algebras/VrfCalculatorAlgebra.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.minting.algebras
 
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 
 trait VrfCalculatorAlgebra[F[_]] {
 

--- a/minting/src/main/scala/org/plasmalabs/minting/interpreters/BlockPacker.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/interpreters/BlockPacker.scala
@@ -1,29 +1,29 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.data.EitherT
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
-import fs2._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
+import fs2.*
 import org.plasmalabs.algebras.ContextlessValidationAlgebra
 import org.plasmalabs.consensus.models.BlockId
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.implicits._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.implicits.*
 import org.plasmalabs.ledger.interpreters.{QuivrContext, RegistrationAccumulator}
 import org.plasmalabs.ledger.models.{MempoolGraph, TransactionSemanticError}
 import org.plasmalabs.minting.algebras.BlockPackerAlgebra
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.node.models.FullBlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.{TransactionAuthorizationVerifier, TransactionCostCalculator}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 
 import scala.collection.immutable.ListSet
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
  * Implements a BlockPackerAlgebra which uses the graph-nature of the Mempool combined with a Transaction Scoring algorithm to produce an "ideal" block body.

--- a/minting/src/main/scala/org/plasmalabs/minting/interpreters/BlockProducer.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/interpreters/BlockProducer.scala
@@ -1,35 +1,35 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.data.OptionT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import fs2._
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
+import fs2.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
 import org.plasmalabs.algebras.{ClockAlgebra, Stats}
-import org.plasmalabs.catsutils._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.catsutils.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.consensus.interpreters.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.interpreters._
 import org.plasmalabs.consensus.models.{BlockId, ProtocolVersion, SlotData, SlotId, StakingAddress}
 import org.plasmalabs.eventtree.EventSourcedState
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.minting.algebras.{BlockPackerAlgebra, BlockProducerAlgebra, StakingAlgebra}
 import org.plasmalabs.minting.models.VrfHit
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
 import org.plasmalabs.models.utility.Sized
 import org.plasmalabs.node.models.{BlockBody, FullBlock, FullBlockBody}
 import org.plasmalabs.quivr.models.SmallData
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.box._
-import org.plasmalabs.sdk.models.transaction._
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.box.*
+import org.plasmalabs.sdk.models.transaction.*
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object BlockProducer {
 

--- a/minting/src/main/scala/org/plasmalabs/minting/interpreters/OperationalKeyMaker.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/interpreters/OperationalKeyMaker.scala
@@ -1,25 +1,25 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.Traverse
-import cats.data._
-import cats.effect.implicits._
+import cats.data.*
+import cats.effect.implicits.*
 import cats.effect.{Async, Deferred, MonadCancelThrow, Ref, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
-import org.plasmalabs.algebras.ClockAlgebra.implicits._
-import org.plasmalabs.algebras._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.algebras.*
+import org.plasmalabs.algebras.ClockAlgebra.implicits.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.algebras.{ConsensusValidationStateAlgebra, LeaderElectionValidationAlgebra}
-import org.plasmalabs.consensus.models.{VrfConfig, _}
+import org.plasmalabs.consensus.models.{VrfConfig, *}
 import org.plasmalabs.crypto.generation.mnemonic.Entropy
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
-import org.plasmalabs.crypto.signing._
-import org.plasmalabs.minting.algebras._
+import org.plasmalabs.crypto.signing.*
+import org.plasmalabs.minting.algebras.*
 import org.plasmalabs.minting.models.OperationalKeyOut
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/minting/src/main/scala/org/plasmalabs/minting/interpreters/Staking.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/interpreters/Staking.scala
@@ -1,23 +1,23 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.data.OptionT
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.catsutils._
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.catsutils.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.consensus.thresholdEvidence
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.crypto.signing.Ed25519
-import org.plasmalabs.minting.algebras._
+import org.plasmalabs.minting.algebras.*
 import org.plasmalabs.minting.models.VrfHit
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.sdk.models.LockAddress
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 

--- a/minting/src/main/scala/org/plasmalabs/minting/interpreters/VrfCalculator.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/interpreters/VrfCalculator.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.minting.interpreters
 
-import cats.effect._
+import cats.effect.*
 import cats.effect.implicits.effectResourceOps
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.typeclasses.implicits._
+import org.plasmalabs.codecs.bytes.typeclasses.implicits.*
 import org.plasmalabs.consensus.models.VrfArgument
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.minting.algebras.VrfCalculatorAlgebra
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 

--- a/minting/src/main/scala/org/plasmalabs/minting/models/OperationalKeyOut.scala
+++ b/minting/src/main/scala/org/plasmalabs/minting/models/OperationalKeyOut.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.minting.models
 
 import com.google.protobuf.ByteString
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.models.Slot
 
 case class OperationalKeyOut(

--- a/minting/src/test/scala/org/plasmalabs/minting/interpreters/BlockPackerSpec.scala
+++ b/minting/src/test/scala/org/plasmalabs/minting/interpreters/BlockPackerSpec.scala
@@ -1,35 +1,35 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ContextlessValidationAlgebra
 import org.plasmalabs.consensus.models.BlockId
-import org.plasmalabs.ledger.algebras._
+import org.plasmalabs.ledger.algebras.*
 import org.plasmalabs.ledger.models.{
   MempoolGraph,
   RewardQuantities,
   TransactionSemanticError,
   TransactionSemanticErrors
 }
-import org.plasmalabs.models.ModelGenerators._
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.models.Slot
 import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.quivr.runtime.DynamicContext
-import org.plasmalabs.sdk.generators.ModelGenerators._
-import org.plasmalabs.sdk.models._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
+import org.plasmalabs.sdk.models.*
 import org.plasmalabs.sdk.models.box.{Attestation, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.TransactionAuthorizationError
-import org.plasmalabs.sdk.validation.algebras._
+import org.plasmalabs.sdk.validation.algebras.*
 import org.scalacheck.Test
 import org.scalamock.munit.AsyncMockFactory
 
 import java.util.concurrent.TimeoutException
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class BlockPackerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]

--- a/minting/src/test/scala/org/plasmalabs/minting/interpreters/BlockProducerSpec.scala
+++ b/minting/src/test/scala/org/plasmalabs/minting/interpreters/BlockProducerSpec.scala
@@ -2,35 +2,35 @@ package org.plasmalabs.minting.interpreters
 
 import cats.effect.std.Queue
 import cats.effect.{Async, IO}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import fs2._
+import fs2.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.ClockAlgebra
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
+import org.plasmalabs.consensus.interpreters.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.interpreters._
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, ProtocolVersion, SlotData, StakingAddress}
 import org.plasmalabs.eventtree.EventSourcedState
 import org.plasmalabs.ledger.algebras.TransactionRewardCalculatorAlgebra
 import org.plasmalabs.ledger.models.{AssetId, RewardQuantities}
 import org.plasmalabs.minting.algebras.{BlockPackerAlgebra, StakingAlgebra}
-import org.plasmalabs.minting.models._
-import org.plasmalabs.models.ModelGenerators._
+import org.plasmalabs.minting.models.*
+import org.plasmalabs.models.ModelGenerators.*
 import org.plasmalabs.models.VersionId
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.generators.node.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.generators.node.ModelGenerators.*
 import org.plasmalabs.node.models.{FullBlock, FullBlockBody}
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.plasmalabs.sdk.models.box.{FungibilityType, QuantityDescriptorType}
 import org.plasmalabs.sdk.models.{GroupId, LockAddress, SeriesId}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.scalacheck.Test
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
 import scala.collection.immutable.NumericRange
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class BlockProducerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]

--- a/minting/src/test/scala/org/plasmalabs/minting/interpreters/OperationalKeyMakerSpec.scala
+++ b/minting/src/test/scala/org/plasmalabs/minting/interpreters/OperationalKeyMakerSpec.scala
@@ -3,28 +3,28 @@ package org.plasmalabs.minting.interpreters
 import cats.data.Chain
 import cats.effect.IO.asyncForIO
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Monad}
 import com.google.common.primitives.Longs
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.models.SecretKeyKesProduct
-import org.plasmalabs.crypto.signing._
+import org.plasmalabs.crypto.signing.*
 import org.plasmalabs.minting.algebras.{OperationalKeyMakerAlgebra, VrfCalculatorAlgebra}
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
-import org.plasmalabs.models.utility._
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 import org.scalamock.munit.AsyncMockFactory
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.util.Random
 
 class OperationalKeyMakerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/minting/src/test/scala/org/plasmalabs/minting/interpreters/StakingSpec.scala
+++ b/minting/src/test/scala/org/plasmalabs/minting/interpreters/StakingSpec.scala
@@ -1,28 +1,28 @@
 package org.plasmalabs.minting.interpreters
 
 import cats.Monad
+import cats.effect.*
 import cats.effect.IO.asyncForIO
-import cats.effect._
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.algebras.Stats.Implicits.*
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.consensus.thresholdEvidence
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.minting.algebras.{OperationalKeyMakerAlgebra, VrfCalculatorAlgebra}
 import org.plasmalabs.minting.models.{OperationalKeyOut, VrfHit}
+import org.plasmalabs.models.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.plasmalabs.sdk.models.{LockAddress, LockId}
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
-import scodec.bits._
+import scodec.bits.*
 
 class StakingSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]

--- a/minting/src/test/scala/org/plasmalabs/minting/interpreters/VrfCalculatorSpec.scala
+++ b/minting/src/test/scala/org/plasmalabs/minting/interpreters/VrfCalculatorSpec.scala
@@ -5,13 +5,13 @@ import cats.effect.IO.asyncForIO
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.plasmalabs.sdk.utils.CatsUnsafeResource
 import org.scalamock.munit.AsyncMockFactory
-import scodec.bits._
+import scodec.bits.*
 
 class VrfCalculatorSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
   type F[A] = IO[A]

--- a/models/src/main/scala/org/plasmalabs/models/UnsignedBlockHeader.scala
+++ b/models/src/main/scala/org/plasmalabs/models/UnsignedBlockHeader.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.models
 
 import com.google.protobuf.ByteString
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 
 case class UnsignedBlockHeader(
   parentHeaderId:                BlockId,

--- a/models/src/main/scala/org/plasmalabs/models/p2p/package.scala
+++ b/models/src/main/scala/org/plasmalabs/models/p2p/package.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.models
 
 import cats.Show
-import cats.implicits._
+import cats.implicits.*
 
 package object p2p {
 

--- a/models/src/main/scala/org/plasmalabs/models/protocol/ConfigConverter.scala
+++ b/models/src/main/scala/org/plasmalabs/models/protocol/ConfigConverter.scala
@@ -1,15 +1,15 @@
 package org.plasmalabs.models.protocol
 
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
-import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.scala._
+import com.fasterxml.jackson.module.scala.*
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.quivr.models
 import org.plasmalabs.quivr.models.Int128
-import org.plasmalabs.sdk.models.box.Value._
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.models.box.Value.*
+import org.plasmalabs.sdk.syntax.*
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag

--- a/models/src/test/scala/org/plasmalabs/models/ModelGenerators.scala
+++ b/models/src/test/scala/org/plasmalabs/models/ModelGenerators.scala
@@ -4,9 +4,9 @@ import cats.data.{NonEmptyChain, NonEmptyList}
 import com.google.protobuf.ByteString
 import org.plasmalabs.consensus.models.{ProtocolVersion, StakingAddress}
 import org.plasmalabs.models.generators.common.ModelGenerators.genSizedStrictByteString
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.scalacheck.rng.Seed
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/models/src/test/scala/org/plasmalabs/models/generators/consensus/ModelGenerators.scala
+++ b/models/src/test/scala/org/plasmalabs/models/generators/consensus/ModelGenerators.scala
@@ -2,9 +2,9 @@ package org.plasmalabs.models.generators.consensus
 
 import cats.data.{Chain, NonEmptyChain}
 import com.google.protobuf.ByteString
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.models.generators.common.ModelGenerators._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.models.generators.common.ModelGenerators.*
+import org.plasmalabs.models.utility.*
 import org.scalacheck.{Arbitrary, Gen}
 
 import scala.annotation.tailrec

--- a/models/src/test/scala/org/plasmalabs/models/generators/node/ModelGenerators.scala
+++ b/models/src/test/scala/org/plasmalabs/models/generators/node/ModelGenerators.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.models.generators.node
 
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitraryHeader
-import org.plasmalabs.node.models._
-import org.plasmalabs.sdk.generators.ModelGenerators._
+import org.plasmalabs.node.models.*
+import org.plasmalabs.sdk.generators.ModelGenerators.*
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ModelGenerators {

--- a/models/src/test/scala/org/plasmalabs/models/protocol/ConfigConverterTest.scala
+++ b/models/src/test/scala/org/plasmalabs/models/protocol/ConfigConverterTest.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.models.protocol
 
 import munit.FunSuite
-import org.plasmalabs.models.protocol.RatioCodec._
+import org.plasmalabs.models.protocol.RatioCodec.*
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.quivr.models.{Ratio => QuivrRatio}
+import org.plasmalabs.quivr.models.Ratio as QuivrRatio
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 
 case class SimpleTest1(stringPar: String, intPar: Int, longPar: Long)

--- a/models/src/test/scala/org/plasmalabs/models/utility/SizedSpec.scala
+++ b/models/src/test/scala/org/plasmalabs/models/utility/SizedSpec.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.models.utility
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.scalamock.munit.AsyncMockFactory
 
 class SizedSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {

--- a/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/ApplicationConfig.scala
+++ b/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/ApplicationConfig.scala
@@ -2,8 +2,8 @@ package org.plasmalabs.networkdelayer
 
 import cats.Show
 import com.typesafe.config.Config
-import pureconfig.generic.derivation.default._
-import pureconfig.{ConfigSource, _}
+import pureconfig.generic.derivation.default.*
+import pureconfig.{ConfigSource, *}
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/Args.scala
+++ b/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/Args.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.networkdelayer
 
 import cats.Show
-import mainargs._
+import mainargs.*
 import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs}
 
 @main

--- a/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/NetworkDelayer.scala
+++ b/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/NetworkDelayer.scala
@@ -1,19 +1,19 @@
 package org.plasmalabs.networkdelayer
 
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Resource
 import cats.effect.{Async, IO}
-import cats.implicits._
-import com.comcast.ip4s._
+import cats.implicits.*
+import com.comcast.ip4s.*
 import com.typesafe.config.Config
-import fs2._
+import fs2.*
 import fs2.io.net.{Network, Socket}
 import org.plasmalabs.common.application.IOBaseApp
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
  * An application  which intercepts TCP connections and induces bandwidth and latency throttling.

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainMultiplexedBuffers.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainMultiplexedBuffers.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.networking.blockchain
 
 import cats.effect.{Async, Resource}
-import cats.implicits._
-import org.plasmalabs.consensus.models._
+import cats.implicits.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.networking.multiplexer.MultiplexedBuffer
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainMultiplexerId.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainMultiplexerId.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.networking.blockchain
 
-import cats.implicits._
+import cats.implicits.*
 
 /**
  * An ADT of blockchain-specific multiplexer ports

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainNetwork.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainNetwork.scala
@@ -1,19 +1,19 @@
 package org.plasmalabs.networking.blockchain
 
-import cats.effect._
-import cats.effect.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
 import cats.effect.std.{Mutex, Random}
-import cats.implicits._
-import fs2._
+import cats.implicits.*
+import fs2.*
 import fs2.concurrent.Topic
 import org.plasmalabs.crypto.signing.Ed25519
 import org.plasmalabs.networking.multiplexer.MultiplexedReaderWriter
-import org.plasmalabs.networking.p2p._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.networking.p2p.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object BlockchainNetwork {
 

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerClient.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerClient.scala
@@ -1,18 +1,18 @@
 package org.plasmalabs.networking.blockchain
 
-import cats._
+import cats.*
 import cats.data.OptionT
 import cats.effect.kernel.Sync
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.networking.p2p.ConnectedPeer
-import org.plasmalabs.node.models._
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.node.models.*
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 /**

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServer.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServer.scala
@@ -2,20 +2,20 @@ package org.plasmalabs.networking.blockchain
 
 import cats.data.Chain
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import fs2.concurrent.Topic
 import org.plasmalabs.blockchain.BlockchainCore
-import org.plasmalabs.catsutils._
+import org.plasmalabs.catsutils.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
-import org.plasmalabs.models.protocol.BigBangConstants._
+import org.plasmalabs.models.protocol.BigBangConstants.*
 import org.plasmalabs.networking.fsnetwork.RemotePeer
 import org.plasmalabs.networking.p2p.PeerConnectionChanges.RemotePeerApplicationLevel
 import org.plasmalabs.networking.p2p.{ConnectedPeer, PeerConnectionChange}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServerAlgebra.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServerAlgebra.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.networking.blockchain
 
-import fs2._
+import fs2.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 

--- a/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainSocketHandler.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/blockchain/BlockchainSocketHandler.scala
@@ -1,19 +1,19 @@
 package org.plasmalabs.networking.blockchain
 
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.std.{Mutex, Queue}
 import cats.effect.{Async, Deferred, Resource}
-import cats.implicits._
-import fs2._
-import org.plasmalabs.codecs.bytes.tetra.TetraScodecCodecs._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import cats.implicits.*
+import fs2.*
+import org.plasmalabs.codecs.bytes.tetra.TetraScodecCodecs.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.codecs.bytes.typeclasses.Transmittable
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.models.Bytes
 import org.plasmalabs.networking.multiplexer.{MultiplexedBuffer, MultiplexedReaderWriter}
 import org.plasmalabs.networking.p2p.ConnectedPeer
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/ActorPeerHandlerBridgeAlgebra.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.networking.fsnetwork
 
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.kernel.Sync
 import cats.effect.{Async, Deferred, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Monad, MonadThrow}
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.Stats
@@ -11,16 +11,16 @@ import org.plasmalabs.blockchain.BlockchainCore
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.NetworkCommands
 import org.plasmalabs.networking.blockchain.{BlockchainPeerClient, BlockchainPeerHandlerAlgebra}
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.p2p.{ConnectedPeer, DisconnectedPeer, PeerConnectionChange}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BestChain.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BestChain.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.networking.fsnetwork
 
-import cats.data._
+import cats.data.*
 import cats.implicits.catsSyntaxEq
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 case class BestChain(slotData: NonEmptyChain[SlotData]) {
   val last: SlotData = slotData.last

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockApplyError.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockApplyError.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.networking.fsnetwork
 
 import cats.data.NonEmptyChain
-import cats.implicits._
+import cats.implicits.*
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.plasmalabs.consensus.models.{BlockHeaderValidationFailure, BlockId}
 import org.plasmalabs.ledger.models.BodyValidationError
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 
 sealed abstract class BlockApplyError extends Exception
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockChecker.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockChecker.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.networking.fsnetwork
 
-import cats.data._
+import cats.data.*
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.plasmalabs.actor.{Actor, Fsm}
@@ -10,21 +10,21 @@ import org.plasmalabs.algebras.Store
 import org.plasmalabs.blockchain.Validators
 import org.plasmalabs.catsutils.faAsFAClockOps
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.ledger.implicits._
+import org.plasmalabs.ledger.implicits.*
 import org.plasmalabs.ledger.interpreters.QuivrContext
 import org.plasmalabs.ledger.models.{BodyProposalValidationContext, BodyValidationError, StaticBodyValidationContext}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.fsnetwork.BlockApplyError.BodyApplyException.BodyValidationException
 import org.plasmalabs.networking.fsnetwork.BlockApplyError.HeaderApplyException.HeaderValidationException
 import org.plasmalabs.networking.fsnetwork.BlockApplyError.{BodyApplyException, HeaderApplyException}
-import org.plasmalabs.networking.fsnetwork.BlockChecker.Message._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.BlockChecker.Message.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import org.plasmalabs.node.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.node.models.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 import scala.collection.Searching

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockDownloadError.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/BlockDownloadError.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.networking.fsnetwork
 
 import cats.data.NonEmptyChain
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.consensus.models.BlockId
-import org.plasmalabs.ledger.implicits._
+import org.plasmalabs.ledger.implicits.*
 import org.plasmalabs.models.TxRoot
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.validation.TransactionSyntaxError
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 sealed abstract class BlockDownloadError extends Exception {
   def notCritical: Boolean

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/DnsResolver.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/DnsResolver.scala
@@ -3,10 +3,10 @@ package org.plasmalabs.networking.fsnetwork
 import cats.Monad
 import cats.data.OptionT
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import com.comcast.ip4s.{Dns, Hostname}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 
 import java.time.Duration
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/DnsReverseResolver.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/DnsReverseResolver.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.data.OptionT
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Monad}
 import com.comcast.ip4s.{Dns, IpAddress}
 import com.github.benmanes.caffeine.cache.Caffeine
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/NetworkAlgebra.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/NetworkAlgebra.scala
@@ -5,12 +5,12 @@ import cats.effect.{Async, Resource}
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.plasmalabs.algebras.{ClockAlgebra, Stats, Store}
 import org.plasmalabs.blockchain.Validators
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import org.plasmalabs.networking.fsnetwork.Notifier.NotifierActor

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/NetworkManager.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/NetworkManager.scala
@@ -5,16 +5,16 @@ import cats.data.NonEmptyChain
 import cats.effect.Async
 import cats.effect.implicits.genSpawnOps
 import cats.effect.kernel.{Outcome, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.blockchain.BlockchainCore
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.NetworkCommands
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.p2p.{DisconnectedPeer, PeerConnectionChange, PeerConnectionChanges}
 import org.typelevel.log4cats.Logger

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/Notifier.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/Notifier.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.effect.kernel.{Async, Fiber}
 import cats.effect.{Resource, Spawn}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.networking.fsnetwork.Notifier.Message.StartNotifications
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.typelevel.log4cats.Logger
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/P2PShowInstances.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/P2PShowInstances.scala
@@ -5,15 +5,15 @@ import cats.implicits.showInterpolator
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
 import org.plasmalabs.consensus.models.{BlockHeaderToBodyValidationFailure, BlockHeaderValidationFailure}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.byteStringToByteVector
-import org.plasmalabs.networking.fsnetwork.NetworkQualityError._
+import org.plasmalabs.networking.fsnetwork.NetworkQualityError.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.Message.PingPongMessagePing
 import org.plasmalabs.networking.p2p.ConnectedPeer
-import org.plasmalabs.node.models._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.node.models.*
+import org.plasmalabs.typeclasses.implicits.*
 
-import java.time._
+import java.time.*
 
 trait P2PShowInstances {
   implicit val showHostId: Show[HostId] = id => show"${id.id.toBase58.take(8)}..."

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerActor.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerActor.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.networking.fsnetwork
 
 import cats.data.{EitherT, NonEmptyChain, OptionT}
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.{Async, Concurrent, Resource}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.consensus.algebras.{BlockHeaderToBodyValidationAlgebra, ChainSelectionAlgebra, LocalChainAlgebra}
@@ -11,11 +11,11 @@ import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.KnownHostOps
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
-import org.plasmalabs.networking.fsnetwork.PeerActor.Message._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
+import org.plasmalabs.networking.fsnetwork.PeerActor.Message.*
 import org.plasmalabs.networking.fsnetwork.PeerBlockBodyFetcher.PeerBlockBodyFetcherActor
 import org.plasmalabs.networking.fsnetwork.PeerBlockHeaderFetcher.PeerBlockHeaderFetcherActor
 import org.plasmalabs.networking.fsnetwork.PeerMempoolTransactionSync.PeerMempoolTransactionSyncActor
@@ -25,7 +25,7 @@ import org.plasmalabs.node.models.{BlockBody, CurrentKnownHostsReq, PingMessage}
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 import scala.util.Random

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerBlockBodyFetcher.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerBlockBodyFetcher.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.networking.fsnetwork
 import cats.MonadThrow
 import cats.data.{EitherT, NonEmptyChain, OptionT}
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.algebras.Store
@@ -11,17 +11,17 @@ import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.algebras.BlockHeaderToBodyValidationAlgebra
 import org.plasmalabs.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
-import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import org.plasmalabs.node.models.{Block, BlockBody}
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object PeerBlockBodyFetcher {

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerBlockHeaderFetcher.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerBlockHeaderFetcher.scala
@@ -4,27 +4,27 @@ import cats.MonadThrow
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.kernel.{Async, Fiber}
 import cats.effect.{Resource, Spawn}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.algebras.{ClockAlgebra, Store, StoreWriter}
 import org.plasmalabs.catsutils.faAsFAClockOps
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.consensus._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.consensus.*
 import org.plasmalabs.consensus.algebras.{ChainSelectionAlgebra, LocalChainAlgebra}
 import org.plasmalabs.consensus.models.{BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError
-import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
-import org.plasmalabs.networking.fsnetwork.PeerBlockHeaderFetcher.CompareResult._
+import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
+import org.plasmalabs.networking.fsnetwork.PeerBlockHeaderFetcher.CompareResult.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object PeerBlockHeaderFetcher {

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerMempoolTransactionSync.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerMempoolTransactionSync.scala
@@ -3,22 +3,22 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.OptionT
 import cats.effect.kernel.Fiber
 import cats.effect.{Async, Ref, Resource, Spawn}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.consensus.algebras.LocalChainAlgebra
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError.UnknownError
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 object PeerMempoolTransactionSync {

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerSlotDataStore.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeerSlotDataStore.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.networking.fsnetwork
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.plasmalabs.algebras.{Store, StoreReader}
 import org.plasmalabs.consensus.models.{BlockId, SlotData}

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeersHandler.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeersHandler.scala
@@ -3,9 +3,9 @@ package org.plasmalabs.networking.fsnetwork
 import cats.Applicative
 import cats.data.Chain
 import cats.effect.Async
-import cats.implicits._
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import cats.implicits.*
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeerActor.PeerActor
 import org.plasmalabs.networking.fsnetwork.PeersHandler.allowedTransition
 import org.typelevel.log4cats.Logger

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeersManager.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/PeersManager.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Parallel, Show}
 import com.github.benmanes.caffeine.cache.Cache
 import org.plasmalabs.actor.{Actor, Fsm}
@@ -14,23 +14,23 @@ import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.networking._
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.networking.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockChecker.BlockCheckerActor
-import org.plasmalabs.networking.fsnetwork.DnsResolverHTInstances._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.DnsResolverHTInstances.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.networking.fsnetwork.PeerActor.PeerActor
-import org.plasmalabs.networking.fsnetwork.PeersManager.Message._
+import org.plasmalabs.networking.fsnetwork.PeersManager.Message.*
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import org.plasmalabs.networking.fsnetwork.ReverseDnsResolverHTInstances._
-import org.plasmalabs.networking.p2p._
+import org.plasmalabs.networking.fsnetwork.ReverseDnsResolverHTInstances.*
+import org.plasmalabs.networking.p2p.*
 import org.plasmalabs.node.models.{BlockBody, KnownHost}
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/RequestsProxy.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/RequestsProxy.scala
@@ -2,19 +2,19 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import org.plasmalabs.actor.{Actor, Fsm}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData, SlotId}
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.{BlockBodyOrTransactionError, BlockHeaderDownloadError}
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
-import org.plasmalabs.networking.fsnetwork.RequestsProxy.Message._
+import org.plasmalabs.networking.fsnetwork.RequestsProxy.Message.*
 import org.plasmalabs.node.models.BlockBody
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import scalacache.Entry
 import scalacache.caffeine.CaffeineCache

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/SelectorColdToWarm.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/SelectorColdToWarm.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.networking.fsnetwork
 
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/SelectorWarmToHot.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/SelectorWarmToHot.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.networking.fsnetwork
 
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 
 import scala.util.Random
 

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/TransactionFetcher.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/TransactionFetcher.scala
@@ -3,17 +3,17 @@ package org.plasmalabs.networking.fsnetwork
 import cats.MonadThrow
 import cats.data.EitherT
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.algebras.Store
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
-import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError._
-import org.plasmalabs.networking.fsnetwork.P2PShowInstances._
+import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError.*
+import org.plasmalabs.networking.fsnetwork.P2PShowInstances.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
 class TransactionFetcher[F[_]: Async: Logger](

--- a/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/package.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/fsnetwork/package.scala
@@ -2,14 +2,14 @@ package org.plasmalabs.networking
 
 import cats.data.{Chain, NonEmptyChain, OptionT}
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Monad, MonadThrow}
 import com.github.benmanes.caffeine.cache.Cache
 import org.plasmalabs.algebras.Store
-import org.plasmalabs.codecs.bytes.scodecs.valuetypes._
+import org.plasmalabs.codecs.bytes.scodecs.valuetypes.*
 import org.plasmalabs.consensus.algebras.LocalChainAlgebra
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.node.models.BlockBody
 import org.typelevel.log4cats.Logger

--- a/networking/src/main/scala/org/plasmalabs/networking/multiplexer/MultiplexedBuffer.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/multiplexer/MultiplexedBuffer.scala
@@ -2,10 +2,10 @@ package org.plasmalabs.networking.multiplexer
 
 import cats.MonadThrow
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.std.Queue
 import cats.effect.{Async, Deferred, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 
 /**

--- a/networking/src/main/scala/org/plasmalabs/networking/multiplexer/MultiplexedReaderWriter.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/multiplexer/MultiplexedReaderWriter.scala
@@ -2,18 +2,18 @@ package org.plasmalabs.networking.multiplexer
 
 import cats.Monad
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.std.Mutex
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.google.common.primitives.Ints
 import com.google.protobuf.ByteString
-import fs2._
+import fs2.*
 import fs2.io.net.Socket
 import org.plasmalabs.models.Bytes
-import org.plasmalabs.networking._
+import org.plasmalabs.networking.*
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
  * Provides functions which read and write data to an underlying socket

--- a/networking/src/main/scala/org/plasmalabs/networking/p2p/ConnectedPeer.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/p2p/ConnectedPeer.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.networking.p2p
 
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.models.Bytes
 import org.plasmalabs.models.p2p.RemoteAddress
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 case class ConnectedPeer(remoteAddress: RemoteAddress, p2pVK: Bytes, networkVersion: Bytes) {
   override def toString: String = show"ConnectedPeer(address=$remoteAddress, id=$p2pVK, version=$networkVersion)"

--- a/networking/src/main/scala/org/plasmalabs/networking/p2p/FS2P2PServer.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/p2p/FS2P2PServer.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.networking.p2p
 
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.std.Random
 import cats.effect.{Async, Resource}
-import cats.implicits._
-import com.comcast.ip4s._
+import cats.implicits.*
+import com.comcast.ip4s.*
 import fs2.Stream
 import fs2.concurrent.Topic
-import fs2.io.net._
+import fs2.io.net.*
 import org.plasmalabs.crypto.signing.Ed25519
 import org.plasmalabs.models.Bytes
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.SocketAddressOps
 import org.plasmalabs.networking.blockchain.NetworkProtocolVersions
 import org.typelevel.log4cats.Logger

--- a/networking/src/main/scala/org/plasmalabs/networking/p2p/PeerIdentity.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/p2p/PeerIdentity.scala
@@ -3,12 +3,12 @@ package org.plasmalabs.networking.p2p
 import cats.data.{EitherT, OptionT}
 import cats.effect.std.Random
 import cats.effect.{Async, Resource}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.net.Socket
 import org.plasmalabs.crypto.signing.Ed25519
-import org.plasmalabs.networking._
+import org.plasmalabs.networking.*
 
 object PeerIdentity {
 

--- a/networking/src/main/scala/org/plasmalabs/networking/p2p/PeerVersion.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/p2p/PeerVersion.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.networking.p2p
 
 import cats.data.{EitherT, OptionT}
 import cats.effect.Async
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.net.Socket
-import org.plasmalabs.networking._
+import org.plasmalabs.networking.*
 
 object PeerVersion {
 

--- a/networking/src/main/scala/org/plasmalabs/networking/package.scala
+++ b/networking/src/main/scala/org/plasmalabs/networking/package.scala
@@ -2,11 +2,11 @@ package org.plasmalabs
 
 import cats.Monad
 import cats.data.OptionT
-import cats.implicits._
+import cats.implicits.*
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 import fs2.Chunk
 import fs2.io.net.Socket
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.fsnetwork.RemotePeer
 import org.plasmalabs.node.models.KnownHost
 

--- a/networking/src/test/scala/org/plasmalabs/networking/NetworkGen.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/NetworkGen.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.networking
 
 import com.google.protobuf.ByteString
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.NetworkProtocolVersions
-import org.plasmalabs.networking.p2p._
+import org.plasmalabs.networking.p2p.*
 import org.scalacheck.{Arbitrary, Gen}
 
 trait NetworkGen {

--- a/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainClientSpec.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainClientSpec.scala
@@ -1,14 +1,14 @@
 package org.plasmalabs.networking.blockchain
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import fs2._
+import fs2.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.networking.p2p.ConnectedPeer
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.scalacheck.Gen

--- a/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServerSpec.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainPeerServerSpec.scala
@@ -2,25 +2,25 @@ package org.plasmalabs.networking.blockchain
 
 import cats.data.NonEmptyChain
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{MonadThrow, Show}
-import fs2._
+import fs2.*
 import fs2.concurrent.Topic
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.blockchain.{BlockchainCore, DataStores}
 import org.plasmalabs.consensus.Consensus
 import org.plasmalabs.consensus.algebras.LocalChainAlgebra
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.ledger.Ledger
 import org.plasmalabs.ledger.algebras.{MempoolAlgebra, TransactionRewardCalculatorAlgebra}
 import org.plasmalabs.ledger.models.{MempoolGraph, RewardQuantities}
-import org.plasmalabs.models.ModelGenerators._
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.generators.node.ModelGenerators._
-import org.plasmalabs.networking.NetworkGen._
+import org.plasmalabs.models.ModelGenerators.*
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.generators.node.ModelGenerators.*
+import org.plasmalabs.networking.NetworkGen.*
 import org.plasmalabs.networking.fsnetwork.RemotePeer
-import org.plasmalabs.networking.fsnetwork.TestHelper._
+import org.plasmalabs.networking.fsnetwork.TestHelper.*
 import org.plasmalabs.networking.p2p.PeerConnectionChanges.RemotePeerApplicationLevel
 import org.plasmalabs.networking.p2p.{ConnectedPeer, PeerConnectionChange}
 import org.plasmalabs.node.models.{BlockBody, CurrentKnownHostsReq, CurrentKnownHostsRes, KnownHost}
@@ -31,7 +31,7 @@ import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class BlockchainPeerServerSpec extends CatsEffectSuite with ScalaCheckEffectSuite with AsyncMockFactory {
 

--- a/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainSocketHandlerSpec.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/blockchain/BlockchainSocketHandlerSpec.scala
@@ -2,20 +2,20 @@ package org.plasmalabs.networking.blockchain
 
 import cats.effect.IO
 import cats.effect.std.{Mutex, Queue}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.codecs.bytes.typeclasses.Transmittable
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.models.Bytes
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.networking.NetworkGen._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.networking.NetworkGen.*
 import org.plasmalabs.networking.multiplexer.MultiplexedReaderWriter
 import org.scalamock.munit.AsyncMockFactory
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class BlockchainSocketHandlerSpec extends CatsEffectSuite with AsyncMockFactory with ScalaCheckEffectSuite {
 

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/ActorPeerHandlerBridgeAlgebraTest.scala
@@ -3,34 +3,34 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.effect.kernel.Sync
 import cats.effect.{Async, IO, Ref, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
 import fs2.Stream
 import fs2.concurrent.Topic
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.algebras.Stats.Implicits._
+import org.plasmalabs.algebras.Stats.Implicits.*
 import org.plasmalabs.algebras.testInterpreters.TestStore
 import org.plasmalabs.blockchain.{BlockchainCore, DataStores, Validators}
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
 import org.plasmalabs.consensus.Consensus
-import org.plasmalabs.consensus.algebras._
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.algebras.*
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.interpreters.SchedulerClock
 import org.plasmalabs.ledger.Ledger
-import org.plasmalabs.ledger.algebras._
-import org.plasmalabs.ledger.models._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitrarySlotData
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.models.utility.NetworkCommands
 import org.plasmalabs.networking.blockchain.{BlockchainPeerClient, NetworkProtocolVersions}
-import org.plasmalabs.networking.fsnetwork.ActorPeerHandlerBridgeAlgebraTest._
+import org.plasmalabs.networking.fsnetwork.ActorPeerHandlerBridgeAlgebraTest.*
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
 import org.plasmalabs.networking.fsnetwork.TestHelper.arbitraryHost
 import org.plasmalabs.networking.p2p.{ConnectedPeer, DisconnectedPeer, PeerConnectionChange}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.quivr.runtime.DynamicContext
 import org.plasmalabs.sdk.generators.ModelGenerators.arbitraryIoTransaction
 import org.plasmalabs.sdk.models.transaction.IoTransaction
@@ -38,7 +38,7 @@ import org.plasmalabs.sdk.models.{Datum, TransactionId}
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.validation.TransactionSyntaxError
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/BlockCheckerTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/BlockCheckerTest.scala
@@ -1,37 +1,37 @@
 package org.plasmalabs.networking.fsnetwork
 
-import cats.data._
+import cats.data.*
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{MonadThrow, Show}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.blockchain.{Validators, ValidatorsImpl}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
-import org.plasmalabs.consensus._
-import org.plasmalabs.consensus.algebras._
+import org.plasmalabs.consensus.*
+import org.plasmalabs.consensus.algebras.*
 import org.plasmalabs.consensus.models.BlockHeaderValidationFailures.NonForwardSlot
-import org.plasmalabs.consensus.models.{BlockHeader, BlockHeaderValidationFailure, BlockId, _}
+import org.plasmalabs.consensus.models.{BlockHeader, BlockHeaderValidationFailure, BlockId, *}
 import org.plasmalabs.crypto.signing.Ed25519VRF
-import org.plasmalabs.ledger.algebras._
+import org.plasmalabs.ledger.algebras.*
+import org.plasmalabs.ledger.models.*
 import org.plasmalabs.ledger.models.BodySemanticErrors.TransactionSemanticErrors
 import org.plasmalabs.ledger.models.TransactionSemanticErrors.InputDataMismatch
-import org.plasmalabs.ledger.models._
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.models.generators.node.ModelGenerators
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.fsnetwork.BlockCheckerTest.F
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import org.plasmalabs.networking.fsnetwork.TestHelper._
+import org.plasmalabs.networking.fsnetwork.TestHelper.*
 import org.plasmalabs.node.models.{Block, BlockBody}
 import org.plasmalabs.quivr.runtime.DynamicContext
 import org.plasmalabs.sdk.models.Datum
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.{TransactionAuthorizationVerifier, TransactionSyntaxVerifier}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory
@@ -39,7 +39,7 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.collection.mutable
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object BlockCheckerTest {
   type F[A] = IO[A]

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/NotifierTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/NotifierTest.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.effect.kernel.Async
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.config.ApplicationConfig.Node.NetworkProperties
 import org.plasmalabs.networking.fsnetwork.NotifierTest.{F, defaultP2PConfig}

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PackageObjectTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PackageObjectTest.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.data.NonEmptyChain
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import cats.{MonadThrow, Show}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
@@ -12,7 +12,7 @@ import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.plasmalabs.networking.fsnetwork.BlockCheckerTest.F
 import org.plasmalabs.networking.fsnetwork.NonEmptyChainFOps
 import org.plasmalabs.networking.fsnetwork.TestHelper.CallHandler3Ops
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
 import org.scalamock.munit.AsyncMockFactory

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerActorTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerActorTest.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.NonEmptyChain
 import cats.effect.kernel.{Async, Sync}
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow, Show}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
@@ -14,8 +14,8 @@ import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.KnownHostOps
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
@@ -27,7 +27,7 @@ import org.plasmalabs.networking.fsnetwork.PeersManager.Message.PingPongMessageP
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
 import org.plasmalabs.networking.fsnetwork.TestHelper.{arbitraryHost, arbitraryKnownHost}
-import org.plasmalabs.node.models._
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.generators.TransactionGenerator
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerBlockBodyFetcherTest.scala
@@ -3,10 +3,10 @@ package org.plasmalabs.networking.fsnetwork
 import cats.MonadThrow
 import cats.data.NonEmptyChain
 import cats.effect.{Async, IO}
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.algebras.BlockHeaderToBodyValidationAlgebra
 import org.plasmalabs.consensus.models.BlockHeaderToBodyValidationFailure.IncorrectTxRoot
 import org.plasmalabs.consensus.models.{BlockHeader, BlockHeaderToBodyValidationFailure, BlockId}
@@ -14,22 +14,22 @@ import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.TxRoot
 import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.plasmalabs.models.generators.consensus.ModelGenerators.nonEmptyChainArbOf
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError.TransactionHaveIncorrectSyntax
 import org.plasmalabs.networking.fsnetwork.PeerBlockHeaderFetcherTest.F
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import org.plasmalabs.networking.fsnetwork.TestHelper._
+import org.plasmalabs.networking.fsnetwork.TestHelper.*
 import org.plasmalabs.node.models.{Block, BlockBody}
 import org.plasmalabs.sdk.generators.TransactionGenerator
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.TransactionSyntaxError.EmptyInputs
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalamock.munit.AsyncMockFactory
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerBlockHeaderFetcherTest.scala
@@ -3,26 +3,26 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.{NonEmptyChain, OptionT}
 import cats.effect.kernel.Sync
 import cats.effect.{Async, IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow, Show}
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.{ClockAlgebra, Store}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.algebras.{ChainSelectionAlgebra, LocalChainAlgebra}
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.eventtree.ParentChildTree
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError
-import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError._
+import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError.*
 import org.plasmalabs.networking.fsnetwork.PeerBlockHeaderFetcherTest.F
 import org.plasmalabs.networking.fsnetwork.PeersManager.PeersManagerActor
 import org.plasmalabs.networking.fsnetwork.RequestsProxy.RequestsProxyActor
-import org.plasmalabs.networking.fsnetwork.TestHelper._
+import org.plasmalabs.networking.fsnetwork.TestHelper.*
 import org.plasmalabs.node.models.BlockBody
 import org.scalacheck.Gen
 import org.scalamock.munit.AsyncMockFactory

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerFilterTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerFilterTest.scala
@@ -2,8 +2,8 @@ package org.plasmalabs.networking.fsnetwork
 
 import com.google.protobuf.ByteString
 import munit.FunSuite
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.networking.fsnetwork._
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.networking.fsnetwork.*
 
 class PeerFilterTest extends FunSuite {
 

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeerMempoolTransactionSyncTest.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.networking.fsnetwork
 
 import cats.data.NonEmptyChain
 import cats.effect.{IO, Sync}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, MonadThrow}
 import fs2.Stream
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -11,8 +11,8 @@ import org.plasmalabs.consensus.algebras.LocalChainAlgebra
 import org.plasmalabs.consensus.models.SlotData
 import org.plasmalabs.ledger.algebras.MempoolAlgebra
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.BlockchainPeerClient
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError
 import org.plasmalabs.networking.fsnetwork.PeerMempoolTransactionSyncTest.F
@@ -30,7 +30,7 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object PeerMempoolTransactionSyncTest {
   type F[A] = IO[A]

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeersManagerTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/PeersManagerTest.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.networking.fsnetwork
 import cats.data.NonEmptyChain
 import cats.effect.kernel.Sync
 import cats.effect.{Async, IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Parallel}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -18,7 +18,7 @@ import org.plasmalabs.ledger.algebras.MempoolAlgebra
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators
 import org.plasmalabs.models.generators.consensus.ModelGenerators.arbitraryBlockId
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.blockchain.{BlockchainPeerClient, NetworkProtocolVersions}
 import org.plasmalabs.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import org.plasmalabs.networking.fsnetwork.NetworkQualityError.{IncorrectPongMessage, NoPongMessage}
@@ -41,7 +41,7 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration.{FiniteDuration, SECONDS}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object PeersManagerTest {
   type F[A] = IO[A]

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/RequestsProxyTest.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/RequestsProxyTest.scala
@@ -3,16 +3,16 @@ package org.plasmalabs.networking.fsnetwork
 import cats.Applicative
 import cats.data.NonEmptyChain
 import cats.effect.{Async, IO}
-import cats.implicits._
+import cats.implicits.*
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.codecs.bytes.tetra.instances.blockHeaderAsBlockHeaderOps
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData, SlotId}
 import org.plasmalabs.models.ModelGenerators.GenHelper
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.models.generators.node.ModelGenerators
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.networking.fsnetwork.BlockChecker.BlockCheckerActor
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockBodyOrTransactionError.BodyNotFoundInPeer
 import org.plasmalabs.networking.fsnetwork.BlockDownloadError.BlockHeaderDownloadError.HeaderNotFoundInPeer

--- a/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/TestHelper.scala
+++ b/networking/src/test/scala/org/plasmalabs/networking/fsnetwork/TestHelper.scala
@@ -1,19 +1,19 @@
 package org.plasmalabs.networking.fsnetwork
 
 import cats.data.NonEmptyChain
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.{BlockHeader, BlockId, SlotData}
 import org.plasmalabs.models.ModelGenerators.GenHelper
 import org.plasmalabs.models.generators.consensus.ModelGenerators
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
-import org.plasmalabs.models.p2p._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
+import org.plasmalabs.models.p2p.*
 import org.plasmalabs.node.models.{BlockBody, KnownHost}
 import org.plasmalabs.sdk.generators.TransactionGenerator
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalamock.function.FunctionAdapter1
 import org.scalamock.handlers.{CallHandler1, CallHandler2, CallHandler3}

--- a/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/KesSum.scala
+++ b/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/KesSum.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.crypto.signing
 
-import org.plasmalabs.crypto.models._
+import org.plasmalabs.crypto.models.*
 import org.plasmalabs.crypto.signing.kes.SumComposition
 
 /**

--- a/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/kes/KesEd25519Blake2b256.scala
+++ b/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/kes/KesEd25519Blake2b256.scala
@@ -5,7 +5,7 @@ import org.plasmalabs.crypto.hash.{Blake2b, Blake2bHash, Hash, digest}
 import org.plasmalabs.crypto.models.KesBinaryTree
 import org.plasmalabs.crypto.signing.eddsa.Ed25519
 
-import KesBinaryTree._
+import KesBinaryTree.*
 
 trait KesEd25519Blake2b256 {
 

--- a/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/kes/SumComposition.scala
+++ b/node-crypto/src/main/scala/org/plasmalabs/crypto/signing/kes/SumComposition.scala
@@ -5,7 +5,7 @@ import org.plasmalabs.crypto.models.KesBinaryTree
 import java.security.SecureRandom
 import scala.annotation.tailrec
 
-import KesBinaryTree._
+import KesBinaryTree.*
 
 /**
  * AMS 2021:

--- a/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/Ed25519VRFSpec.scala
+++ b/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/Ed25519VRFSpec.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.crypto.signing
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.{Decoder, HCursor}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.plasmalabs.crypto.generation.mnemonic.Entropy
-import org.plasmalabs.crypto.utils.EntropySupport._
-import org.plasmalabs.crypto.utils._
+import org.plasmalabs.crypto.utils.*
+import org.plasmalabs.crypto.utils.EntropySupport.*
 import org.scalacheck.effect.PropF
 import scodec.bits.ByteVector
 

--- a/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/KesProductSpec.scala
+++ b/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/KesProductSpec.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.crypto.signing
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.crypto.models._
-import org.plasmalabs.crypto.utils.Generators._
-import org.plasmalabs.crypto.utils.Hex.implicits._
+import org.plasmalabs.crypto.models.*
+import org.plasmalabs.crypto.utils.Generators.*
+import org.plasmalabs.crypto.utils.Hex.implicits.*
 import org.plasmalabs.crypto.utils.KesTestHelper
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF

--- a/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/KesSumSpec.scala
+++ b/node-crypto/src/test/scala/org/plasmalabs/crypto/signing/KesSumSpec.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.crypto.signing
 
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.plasmalabs.crypto.models._
-import org.plasmalabs.crypto.utils.Hex.implicits._
-import org.plasmalabs.crypto.utils.NodeCryptoGenerators._
+import org.plasmalabs.crypto.models.*
+import org.plasmalabs.crypto.utils.Hex.implicits.*
+import org.plasmalabs.crypto.utils.NodeCryptoGenerators.*
 import org.scalacheck.Gen
 import org.scalacheck.effect.PropF
 

--- a/node-crypto/src/test/scala/org/plasmalabs/crypto/utils/KesTestHelper.scala
+++ b/node-crypto/src/test/scala/org/plasmalabs/crypto/utils/KesTestHelper.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.crypto.utils
 
-import org.plasmalabs.crypto.models._
+import org.plasmalabs.crypto.models.*
 
 object KesTestHelper {
 

--- a/node-crypto/src/test/scala/org/plasmalabs/crypto/utils/NodeCryptoGenerators.scala
+++ b/node-crypto/src/test/scala/org/plasmalabs/crypto/utils/NodeCryptoGenerators.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.crypto.utils
 
-import org.plasmalabs.crypto.models._
+import org.plasmalabs.crypto.models.*
 import org.scalacheck.{Arbitrary, Gen}
 
 object NodeCryptoGenerators {

--- a/node/src/main/scala/org/plasmalabs/healthcheck/HealthCheck.scala
+++ b/node/src/main/scala/org/plasmalabs/healthcheck/HealthCheck.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.healthcheck
 
-import cats.effect._
+import cats.effect.*
 import fs2.Stream
 import fs2.concurrent.SignallingRef
 import grpc.health.v1.ServingStatus
-import org.plasmalabs.algebras._
+import org.plasmalabs.algebras.*
 import org.plasmalabs.models.ServiceStatus
 
 /**

--- a/node/src/main/scala/org/plasmalabs/healthcheck/HealthChecker.scala
+++ b/node/src/main/scala/org/plasmalabs/healthcheck/HealthChecker.scala
@@ -9,7 +9,7 @@ import grpc.health.v1.{HealthCheckRequest, HealthCheckResponse, ServingStatus}
 import io.grpc.{Status, StatusException}
 import org.plasmalabs.algebras.HealthCheckAlgebra
 import org.plasmalabs.models.ServiceStatus
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object HealthChecker {
 

--- a/node/src/main/scala/org/plasmalabs/version/VersionReplicator.scala
+++ b/node/src/main/scala/org/plasmalabs/version/VersionReplicator.scala
@@ -3,16 +3,16 @@ package org.plasmalabs.version
 import cats.data.OptionT
 import cats.effect.implicits.genSpawnOps
 import cats.effect.kernel.{Async, Outcome, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.Stream
 import fs2.io.net.Network
-import io.circe.parser._
+import io.circe.parser.*
 import org.http4s.ember.client.EmberClientBuilder
 import org.plasmalabs.algebras.SoftwareVersionAlgebra
 import org.plasmalabs.blockchain.algebras.NodeMetadataAlgebra
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object VersionReplicator {
 

--- a/node/src/main/scala/org/plasmalabs/version/node/ApplicationConfigOps.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/ApplicationConfigOps.scala
@@ -1,29 +1,29 @@
 package org.plasmalabs.node
 
 import cats.Show
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import com.typesafe.config.Config
-import monocle._
-import monocle.macros._
+import monocle.*
+import monocle.macros.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.config.ApplicationConfig.Node
 import org.plasmalabs.config.ApplicationConfig.Node.BigBangs.RegtestConfig
 import org.plasmalabs.config.ApplicationConfig.Node.KnownPeer
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.sdk.codecs.AddressCodecs.decodeAddress
 import org.plasmalabs.sdk.models.LockAddress
 import org.plasmalabs.sdk.utils.Encoding
-import pureconfig._
-import pureconfig.configurable._
+import pureconfig.*
+import pureconfig.configurable.*
 import pureconfig.generic.ProductHint
-import pureconfig.generic.semiauto._
+import pureconfig.generic.semiauto.*
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration.{FiniteDuration, _}
-import scala.jdk.CollectionConverters._
+import scala.concurrent.duration.{FiniteDuration, *}
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 // $COVERAGE-OFF$

--- a/node/src/main/scala/org/plasmalabs/version/node/Args.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/Args.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.node
 
 import cats.Show
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import mainargs._
+import mainargs.*
 import monocle.macros.GenLens
-import monocle.syntax.all._
+import monocle.syntax.all.*
 import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs}
 import org.plasmalabs.consensus.models.StakingAddress
 import org.plasmalabs.sdk.models.LockAddress

--- a/node/src/main/scala/org/plasmalabs/version/node/DataStoresInit.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/DataStoresInit.scala
@@ -1,40 +1,40 @@
 package org.plasmalabs.node
 
-import cats._
+import cats.*
 import cats.data.NonEmptySet
-import cats.effect._
-import cats.effect.implicits._
-import cats.implicits._
+import cats.effect.*
+import cats.effect.implicits.*
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.io.file.{Files, Path}
 import org.iq80.leveldb.DBFactory
 import org.plasmalabs.algebras.Store
-import org.plasmalabs.blockchain._
+import org.plasmalabs.blockchain.*
 import org.plasmalabs.codecs.bytes.scodecs.valuetypes.ValuetypesCodecs.intCodec
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
 import org.plasmalabs.config.ApplicationConfig
-import org.plasmalabs.consensus._
+import org.plasmalabs.consensus.*
 import org.plasmalabs.consensus.interpreters.BlockHeaderToBodyValidation
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.signing.Ed25519VRF
 import org.plasmalabs.db.leveldb.LevelDbStore
 import org.plasmalabs.interpreters.CacheStore
-import org.plasmalabs.interpreters.ContainsCacheStore._
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.interpreters.ContainsCacheStore.*
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.{Epoch, ProposalId, VersionId}
-import org.plasmalabs.networking.fsnetwork._
-import org.plasmalabs.node.models._
+import org.plasmalabs.networking.fsnetwork.*
+import org.plasmalabs.node.models.*
 import org.plasmalabs.proto.node.EpochData
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 
-import DataStoresInit.DataStoreNames._
+import DataStoresInit.DataStoreNames.*
 
 object DataStoresInit {
 

--- a/node/src/main/scala/org/plasmalabs/version/node/IdleApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/IdleApp.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.node
 
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.grpc.{HealthCheckGrpc, NodeGrpc}
 import org.plasmalabs.healthcheck.HealthCheck
-import org.plasmalabs.node.ApplicationConfigOps._
+import org.plasmalabs.node.ApplicationConfigOps.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/NodeApp.scala
@@ -1,55 +1,55 @@
 package org.plasmalabs.node
 
 import cats.data.OptionT
-import cats.effect.implicits._
+import cats.effect.implicits.*
 import cats.effect.std.{Random, SecureRandom}
 import cats.effect.{Async, IO, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import com.typesafe.config.Config
 import fs2.io.file.Path
 import kamon.Kamon
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.blockchain._
+import org.plasmalabs.blockchain.*
 import org.plasmalabs.blockchain.interpreters.{EpochDataEventSourcedState, EpochDataInterpreter, NodeMetadata}
 import org.plasmalabs.buildinfo.node.BuildInfo
-import org.plasmalabs.catsutils._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.catsutils.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.common.application.IOBaseApp
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.config.ApplicationConfig.Node.KnownPeer
-import org.plasmalabs.consensus._
+import org.plasmalabs.consensus.*
+import org.plasmalabs.consensus.interpreters.*
 import org.plasmalabs.consensus.interpreters.CrossEpochEventSourceState.VotingData
-import org.plasmalabs.consensus.interpreters._
 import org.plasmalabs.consensus.models.{BlockId, VrfConfig}
 import org.plasmalabs.crypto.hash.Blake2b512
 import org.plasmalabs.crypto.signing.Ed25519
 import org.plasmalabs.eventtree.ParentChildTree
-import org.plasmalabs.grpc.{HealthCheckGrpc, _}
+import org.plasmalabs.grpc.{HealthCheckGrpc, *}
 import org.plasmalabs.healthcheck.HealthCheck
-import org.plasmalabs.indexer._
-import org.plasmalabs.interpreters._
+import org.plasmalabs.indexer.*
+import org.plasmalabs.interpreters.*
 import org.plasmalabs.ledger.LedgerImpl
+import org.plasmalabs.ledger.interpreters.*
 import org.plasmalabs.ledger.interpreters.ProposalEventSourceState.ProposalData
-import org.plasmalabs.ledger.interpreters._
 import org.plasmalabs.models.ProposalConfig
-import org.plasmalabs.models.p2p._
-import org.plasmalabs.models.protocol.BigBangConstants._
+import org.plasmalabs.models.p2p.*
+import org.plasmalabs.models.protocol.BigBangConstants.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.models.utility.HasLength.instances.byteStringLength
-import org.plasmalabs.models.utility._
 import org.plasmalabs.networking.p2p.LocalPeer
 import org.plasmalabs.node.cli.ConfiguredCliApp
 import org.plasmalabs.numerics.interpreters.{ExpInterpreter, Log1pInterpreter}
 import org.plasmalabs.sdk.validation.{TransactionCostCalculatorInterpreter, TransactionCostConfig}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.plasmalabs.version.VersionReplicator
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.time.Instant
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
-import ApplicationConfigOps._
+import ApplicationConfigOps.*
 
 object NodeApp extends AbstractNodeApp
 

--- a/node/src/main/scala/org/plasmalabs/version/node/ProtocolVersioner.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/ProtocolVersioner.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.node
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.{Eq, Order}
 import org.plasmalabs.config.ApplicationConfig.Node
 import org.plasmalabs.consensus.models.ProtocolVersion

--- a/node/src/main/scala/org/plasmalabs/version/node/PrunedDataStoresApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/PrunedDataStoresApp.scala
@@ -3,22 +3,22 @@ package org.plasmalabs.node
 import cats.effect.kernel.Async
 import cats.effect.std.Queue
 import cats.effect.{IO, Resource}
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.{Files, Path}
 import org.plasmalabs.algebras.Store
 import org.plasmalabs.blockchain.{DataStores, PrunedDataStores}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.models.utility._
-import org.plasmalabs.node.models._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.node.models.*
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import DataStoresInit.DataStoreNames._
+import DataStoresInit.DataStoreNames.*
 
 class PrunedDataStoresApp(appConfig: ApplicationConfig, prunedDataStorePath: String) {
   type F[A] = IO[A]

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/CliApp.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/CliApp.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.node.cli
 
 import cats.effect.{IO, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.config.ApplicationConfig
 
 class ConfiguredCliApp(appConfig: ApplicationConfig) {

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/ConfigureCommand.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/ConfigureCommand.scala
@@ -4,15 +4,15 @@ import cats.ApplicativeThrow
 import cats.data.OptionT
 import cats.effect.Async
 import cats.effect.std.{Console, Env}
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.{Files, Path}
-import io.circe._
-import io.circe.syntax._
+import io.circe.*
+import io.circe.syntax.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
 import org.plasmalabs.node.AbstractNodeApp
 import org.plasmalabs.sdk.models.LockAddress
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 import java.nio.charset.StandardCharsets
 

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/InitMainnetCommand.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/InitMainnetCommand.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.node.cli
 
 import cats.effect.Async
 import cats.effect.std.Console
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.io.file.{Files, Path}
 import org.plasmalabs.blockchain.BigBang
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.node.ProtocolVersioner
 import org.plasmalabs.node.models.FullBlock
@@ -15,8 +15,8 @@ import org.plasmalabs.sdk.constants.NetworkConstants
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, Event, LockAddress, LockId}
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 
 object InitMainnetCommand {
 

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/InitNetworkHelpers.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/InitNetworkHelpers.scala
@@ -1,15 +1,15 @@
 package org.plasmalabs.node.cli
 
 import cats.MonadThrow
-import cats.data._
-import cats.effect._
+import cats.data.*
+import cats.effect.*
 import cats.effect.std.Console
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration.Duration
 import fs2.io.file.Path
-import org.plasmalabs.blockchain._
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.blockchain.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.models.protocol.{ConfigConverter, ConfigGenesis}
 import org.plasmalabs.node.models.{BlockBody, FullBlock}
@@ -18,8 +18,8 @@ import org.plasmalabs.sdk.models.LockAddress
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.box.Value.ConfigProposal
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
-import org.plasmalabs.sdk.syntax._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.sdk.syntax.*
+import org.plasmalabs.typeclasses.implicits.*
 
 import java.nio.charset.StandardCharsets
 import java.time.format.DateTimeFormatter

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/InitTestnetCommand.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/InitTestnetCommand.scala
@@ -2,10 +2,10 @@ package org.plasmalabs.node.cli
 
 import cats.effect.std.{Console, SecureRandom}
 import cats.effect.{Async, Sync}
-import cats.implicits._
+import cats.implicits.*
 import fs2.io.file.{Files, Path}
 import org.plasmalabs.blockchain.{BigBang, PrivateTestnet, StakerInitializers, StakingInit}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.crypto.hash.Blake2b256
 import org.plasmalabs.node.ProtocolVersioner
@@ -14,7 +14,7 @@ import org.plasmalabs.quivr.models.{Int128, SmallData}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{Datum, Event}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 import java.nio.charset.StandardCharsets
 

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/RegistrationCommandImpl.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/RegistrationCommandImpl.scala
@@ -4,11 +4,11 @@ import cats.MonadThrow
 import cats.data.EitherT
 import cats.effect.std.Console
 import cats.effect.{Async, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.io.file.Path
 import org.plasmalabs.blockchain.{StakerInitializers, StakingInit}
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.config.ApplicationConfig
 import org.plasmalabs.consensus.models.StakingAddress
 import org.plasmalabs.crypto.generation.EntropyToSeed
@@ -17,7 +17,7 @@ import org.plasmalabs.crypto.signing.{Ed25519, Ed25519VRF, KesProduct}
 import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.models.transaction.Schedule
 import org.plasmalabs.sdk.models.{Datum, Event}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 object RegistrationCommand {
 

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/StageResult.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/StageResult.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.node.cli
 
-import cats._
-import cats.implicits._
+import cats.*
+import cats.implicits.*
 
 import scala.annotation.tailrec
 

--- a/node/src/main/scala/org/plasmalabs/version/node/cli/package.scala
+++ b/node/src/main/scala/org/plasmalabs/version/node/cli/package.scala
@@ -3,17 +3,17 @@ package org.plasmalabs.node
 import cats.data.EitherT
 import cats.effect.std.Console
 import cats.effect.{Async, Sync}
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import fs2.Chunk
 import fs2.io.file.{Files, Path}
 import org.plasmalabs.consensus.models.{BlockId, StakingAddress}
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.quivr.models.{Int128, Ratio}
 import org.plasmalabs.sdk.models.LockAddress
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.util.Try
 
 package object cli {

--- a/numerics/src/main/scala/org/plasmalabs/numerics/NumberOps.scala
+++ b/numerics/src/main/scala/org/plasmalabs/numerics/NumberOps.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.numerics
 
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.quivr.models.{Int128, Ratio => QuivrRatio}
+import org.plasmalabs.quivr.models.{Int128, Ratio as QuivrRatio}
 
 import scala.language.implicitConversions
 

--- a/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/ExpInterpreter.scala
+++ b/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/ExpInterpreter.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.numerics.interpreters
 
 import cats.Monad
-import cats.implicits._
-import org.plasmalabs.models.utility._
+import cats.implicits.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.numerics.algebras.Exp
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 
 object ExpInterpreter extends LentzMethod {
 

--- a/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/LentzMethod.scala
+++ b/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/LentzMethod.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.numerics.interpreters
 
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 
 trait LentzMethod {
 

--- a/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/Log1pInterpreter.scala
+++ b/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/Log1pInterpreter.scala
@@ -2,10 +2,10 @@ package org.plasmalabs.numerics.interpreters
 
 import cats.Monad
 import cats.effect.kernel.Sync
-import cats.implicits._
-import org.plasmalabs.models.utility._
+import cats.implicits.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.numerics.algebras.Log1p
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import scalacache.caffeine.CaffeineCache
 
 object Log1pInterpreter extends LentzMethod {

--- a/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/RationalApproximationInterpreter.scala
+++ b/numerics/src/main/scala/org/plasmalabs/numerics/interpreters/RationalApproximationInterpreter.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.numerics.interpreters
 
 import cats.Monad
-import cats.implicits._
+import cats.implicits.*
 import org.plasmalabs.models.utility.Ratio
 import org.plasmalabs.numerics.algebras.RationalApproximation
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 
 object RationalApproximationInterpreter {
 

--- a/numerics/src/test/scala/org/plasmalabs/numerics/interpreters/LentzSpec.scala
+++ b/numerics/src/test/scala/org/plasmalabs/numerics/interpreters/LentzSpec.scala
@@ -1,10 +1,10 @@
 package org.plasmalabs.numerics.interpreters
 
 import cats.effect.IO
-import cats.implicits._
-import munit._
+import cats.implicits.*
+import munit.*
 import org.plasmalabs.models.utility.Ratio
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 
 class LentzSpec extends CatsEffectSuite {
 

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/algebras/DataPublisher.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/algebras/DataPublisher.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.testnetsimulationorchestrator.algebras
 
-import org.plasmalabs.testnetsimulationorchestrator.models._
+import org.plasmalabs.testnetsimulationorchestrator.models.*
 
 /**
  * Exports result of the testnet to an external destination

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/ApplicationConfig.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/ApplicationConfig.scala
@@ -2,8 +2,8 @@ package org.plasmalabs.testnetsimulationorchestrator.app
 
 import cats.Show
 import com.typesafe.config.Config
-import pureconfig.generic.derivation.default._
-import pureconfig.{ConfigSource, _}
+import pureconfig.generic.derivation.default.*
+import pureconfig.{ConfigSource, *}
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/Args.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/Args.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.testnetsimulationorchestrator.app
 
 import cats.Show
-import mainargs._
+import mainargs.*
 import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs}
 
 @main

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/Orchestrator.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/app/Orchestrator.scala
@@ -2,11 +2,11 @@ package org.plasmalabs.testnetsimulationorchestrator.app
 
 import cats.Applicative
 import cats.data.OptionT
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.{Random, SecureRandom}
-import cats.implicits._
+import cats.implicits.*
 import com.typesafe.config.Config
-import fs2._
+import fs2.*
 import fs2.concurrent.Topic
 import org.plasmalabs.algebras.{NodeRpc, SynchronizationTraversalSteps}
 import org.plasmalabs.common.application.IOBaseApp
@@ -14,20 +14,20 @@ import org.plasmalabs.consensus.models.{BlockHeader, BlockId}
 import org.plasmalabs.grpc.NodeGrpc
 import org.plasmalabs.indexer.services.TransactionServiceFs2Grpc
 import org.plasmalabs.interpreters.MultiNodeRpc
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.sdk.models.TransactionId
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.{TransactionCostCalculatorInterpreter, TransactionCostConfig}
 import org.plasmalabs.testnetsimulationorchestrator.algebras.DataPublisher
 import org.plasmalabs.testnetsimulationorchestrator.interpreters.{GcpCsvDataPublisher, K8sSimulationController}
 import org.plasmalabs.testnetsimulationorchestrator.models.{AdoptionDatum, BlockDatum, TransactionDatum}
 import org.plasmalabs.transactiongenerator.interpreters.{Fs2TransactionGenerator, IndexerWalletInitializer}
 import org.plasmalabs.transactiongenerator.models.Wallet
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object Orchestrator
     extends IOBaseApp[Args, ApplicationConfig](

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/interpreters/GcpCsvDataPublisher.scala
@@ -1,17 +1,17 @@
 package org.plasmalabs.testnetsimulationorchestrator.interpreters
 
-import cats.effect._
-import cats.implicits._
-import com.google.cloud.storage._
+import cats.effect.*
+import cats.implicits.*
+import com.google.cloud.storage.*
 import com.google.protobuf.ByteString
-import fs2._
-import org.plasmalabs.codecs.bytes.tetra.instances._
-import org.plasmalabs.models.utility._
+import fs2.*
+import org.plasmalabs.codecs.bytes.tetra.instances.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.testnetsimulationorchestrator.algebras.DataPublisher
 import org.plasmalabs.testnetsimulationorchestrator.models.{AdoptionDatum, BlockDatum, TransactionDatum}
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 
 import java.nio.charset.StandardCharsets
 

--- a/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/interpreters/K8sSimulationController.scala
+++ b/testnet-simulation-orchestrator/src/main/scala/org/plasmalabs/testnetsimulationorchestrator/interpreters/K8sSimulationController.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.testnetsimulationorchestrator.interpreters
 
 import cats.effect.std.Dispatcher
 import cats.effect.{Async, Deferred, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
 import io.kubernetes.client.openapi.apis.CoreV1Api
 import io.kubernetes.client.openapi.models.V1Status
 import io.kubernetes.client.openapi.{ApiCallback, ApiException}

--- a/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraPersistableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraPersistableCodecs.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.codecs.bytes.tetra
 
 import cats.data.NonEmptySet
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.scodecs._
+import org.plasmalabs.codecs.bytes.scodecs.*
 import org.plasmalabs.codecs.bytes.typeclasses.Persistable
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.crypto.models.SecretKeyKesProduct

--- a/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraScodecCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraScodecCodecs.scala
@@ -1,14 +1,14 @@
 package org.plasmalabs.codecs.bytes.tetra
 
-import org.plasmalabs.codecs.bytes.scodecs._
+import org.plasmalabs.codecs.bytes.scodecs.*
 import org.plasmalabs.codecs.bytes.scodecs.valuetypes.byteStringCodec
-import org.plasmalabs.consensus.models._
-import org.plasmalabs.crypto.{models => nodeCryptoModels}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.consensus.models.*
+import org.plasmalabs.crypto.models as nodeCryptoModels
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.node.models.KnownHost
 import scodec.Codec
-import scodec.codecs._
+import scodec.codecs.*
 
 /**
  * Use this object or the package object to access all of the codecs from outside of this package.

--- a/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraSignableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraSignableCodecs.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.codecs.bytes.tetra
 
-import org.plasmalabs.codecs.bytes.typeclasses._
+import org.plasmalabs.codecs.bytes.typeclasses.*
 import org.plasmalabs.models.UnsignedBlockHeader
 
 trait TetraSignableCodecs {

--- a/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraTransmittableCodecs.scala
+++ b/tetra-byte-codecs/src/main/scala/org/plasmalabs/codecs/bytes/tetra/TetraTransmittableCodecs.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.codecs.bytes.tetra
 
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import org.plasmalabs.codecs.bytes.typeclasses.Transmittable
 import org.plasmalabs.consensus.models.BlockId
 import org.plasmalabs.models.utility.Ratio
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import scodec.Codec
-import scodec.codecs._
+import scodec.codecs.*
 
 import scala.util.Try
 

--- a/tetra-byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/tetra/ModelGenerators.scala
+++ b/tetra-byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/tetra/ModelGenerators.scala
@@ -1,9 +1,9 @@
 package org.plasmalabs.codecs.bytes.tetra
 
 import cats.data.NonEmptyChain
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.{BlockHeader, ProtocolVersion, SlotData}
-import org.plasmalabs.models.generators.consensus.ModelGenerators._
+import org.plasmalabs.models.generators.consensus.ModelGenerators.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.sdk.generators.ModelGenerators.arbitraryIoTransaction
 import org.plasmalabs.sdk.models.transaction.IoTransaction

--- a/tetra-byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
+++ b/tetra-byte-codecs/src/test/scala/org/plasmalabs/codecs/bytes/tetra/TetraScodecCodecsSpec.scala
@@ -4,7 +4,7 @@ import cats.{Eq, Show}
 import org.plasmalabs.codecs.bytes.CodecSpec
 import org.plasmalabs.consensus.models.{BlockId, EligibilityCertificate}
 import org.plasmalabs.crypto.models.KesBinaryTree
-import org.plasmalabs.models._
+import org.plasmalabs.models.*
 import org.plasmalabs.models.utility.Ratio
 import org.scalacheck.Gen
 

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/ApplicationConfig.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/ApplicationConfig.scala
@@ -2,8 +2,8 @@ package org.plasmalabs.transactiongenerator.app
 
 import cats.Show
 import com.typesafe.config.Config
-import pureconfig.generic.derivation.default._
-import pureconfig.{ConfigSource, _}
+import pureconfig.generic.derivation.default.*
+import pureconfig.{ConfigSource, *}
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/Args.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/Args.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.transactiongenerator.app
 
 import cats.Show
-import mainargs._
+import mainargs.*
 import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs}
 
 @main

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/TransactionGeneratorApp.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/app/TransactionGeneratorApp.scala
@@ -1,26 +1,26 @@
 package org.plasmalabs.transactiongenerator.app
 
 import cats.Show
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.{Random, SecureRandom}
-import cats.implicits._
+import cats.implicits.*
 import com.typesafe.config.Config
-import fs2._
+import fs2.*
 import org.plasmalabs.algebras.NodeRpc
-import org.plasmalabs.common.application._
+import org.plasmalabs.common.application.*
 import org.plasmalabs.grpc.NodeGrpc
 import org.plasmalabs.indexer.services.TransactionServiceFs2Grpc
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
 import org.plasmalabs.sdk.validation.{TransactionCostCalculatorInterpreter, TransactionCostConfig}
-import org.plasmalabs.transactiongenerator.interpreters._
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.transactiongenerator.interpreters.*
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object TransactionGeneratorApp
     extends IOBaseApp[Args, ApplicationConfig](

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/Fs2TransactionGenerator.scala
@@ -1,24 +1,24 @@
 package org.plasmalabs.transactiongenerator.interpreters
 
 import cats.data.OptionT
-import cats.effect._
+import cats.effect.*
 import cats.effect.std.Random
-import cats.implicits._
+import cats.implicits.*
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
-import fs2._
+import fs2.*
 import org.plasmalabs.quivr.api.Prover
 import org.plasmalabs.quivr.models.SmallData
-import org.plasmalabs.sdk.common.ContainsSignable._
-import org.plasmalabs.sdk.common.ContainsSignable.instances._
-import org.plasmalabs.sdk.models.box._
-import org.plasmalabs.sdk.models.transaction._
+import org.plasmalabs.sdk.common.ContainsSignable.*
+import org.plasmalabs.sdk.common.ContainsSignable.instances.*
+import org.plasmalabs.sdk.models.box.*
+import org.plasmalabs.sdk.models.transaction.*
 import org.plasmalabs.sdk.models.{Datum, Event, TransactionOutputAddress}
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
 import org.plasmalabs.transactiongenerator.algebras.TransactionGenerator
 import org.plasmalabs.transactiongenerator.models.Wallet
-import org.plasmalabs.typeclasses.implicits._
+import org.plasmalabs.typeclasses.implicits.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/GenusWalletInitializer.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/GenusWalletInitializer.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.transactiongenerator.interpreters
 
-import cats.effect._
-import cats.implicits._
+import cats.effect.*
+import cats.implicits.*
 import io.grpc.Metadata
 import org.plasmalabs.indexer.services.{QueryByLockAddressRequest, TransactionServiceFs2Grpc, TxoState}
 import org.plasmalabs.sdk.models.box.Box

--- a/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/package.scala
+++ b/transaction-generator/src/main/scala/org/plasmalabs/transactiongenerator/interpreters/package.scala
@@ -1,11 +1,11 @@
 package org.plasmalabs.transactiongenerator
 
-import org.plasmalabs.quivr.models._
+import org.plasmalabs.quivr.models.*
 import org.plasmalabs.sdk.constants.NetworkConstants
-import org.plasmalabs.sdk.models._
-import org.plasmalabs.sdk.models.box._
+import org.plasmalabs.sdk.models.*
+import org.plasmalabs.sdk.models.box.*
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 import org.plasmalabs.transactiongenerator.models.Wallet
 
 package object interpreters {

--- a/transaction-generator/src/test/scala/org/plasmalabs/transactiongenerator/interpreters/Fs2TransactionGeneratorSpec.scala
+++ b/transaction-generator/src/test/scala/org/plasmalabs/transactiongenerator/interpreters/Fs2TransactionGeneratorSpec.scala
@@ -2,9 +2,9 @@ package org.plasmalabs.transactiongenerator.interpreters
 
 import cats.effect.IO
 import cats.effect.std.{Random, SecureRandom}
-import cats.implicits._
+import cats.implicits.*
 import munit.CatsEffectSuite
-import org.plasmalabs.numerics.implicits._
+import org.plasmalabs.numerics.implicits.*
 import org.plasmalabs.quivr.models.SmallData
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule, UnspentTransactionOutput}

--- a/typeclasses/src/main/scala/org/plasmalabs/typeclasses/ContainsTransactions.scala
+++ b/typeclasses/src/main/scala/org/plasmalabs/typeclasses/ContainsTransactions.scala
@@ -2,20 +2,20 @@ package org.plasmalabs.typeclasses
 
 import cats.Foldable
 import cats.data.ValidatedNec
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import org.plasmalabs.crypto.accumulators.LeafData
 import org.plasmalabs.crypto.accumulators.merkle.MerkleTree
 import org.plasmalabs.crypto.hash.digest.{Digest, Digest32, InvalidDigestFailure}
 import org.plasmalabs.crypto.hash.{Blake2b, Blake2bHash}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.HasLength.instances._
-import org.plasmalabs.models.utility.Lengths._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
+import org.plasmalabs.models.utility.HasLength.instances.*
+import org.plasmalabs.models.utility.Lengths.*
 import org.plasmalabs.node.models.FullBlockBody
 import org.plasmalabs.sdk.models.TransactionId
 import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.syntax._
+import org.plasmalabs.sdk.syntax.*
 
 import scala.language.implicitConversions
 

--- a/typeclasses/src/main/scala/org/plasmalabs/typeclasses/EqInstances.scala
+++ b/typeclasses/src/main/scala/org/plasmalabs/typeclasses/EqInstances.scala
@@ -1,13 +1,13 @@
 package org.plasmalabs.typeclasses
 
 import cats.Eq
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
 import grpc.health.v1.ServingStatus
-import org.plasmalabs.consensus.models._
+import org.plasmalabs.consensus.models.*
 import org.plasmalabs.crypto.generation.mnemonic.Entropy
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility.{Sized, _}
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.{Sized, *}
 import org.plasmalabs.sdk.models.TransactionId
 
 trait EqInstances {

--- a/typeclasses/src/main/scala/org/plasmalabs/typeclasses/ShowInstances.scala
+++ b/typeclasses/src/main/scala/org/plasmalabs/typeclasses/ShowInstances.scala
@@ -1,12 +1,12 @@
 package org.plasmalabs.typeclasses
 
 import cats.Show
-import cats.implicits._
+import cats.implicits.*
 import com.google.protobuf.ByteString
-import org.plasmalabs.codecs.bytes.tetra.instances._
+import org.plasmalabs.codecs.bytes.tetra.instances.*
 import org.plasmalabs.consensus.models.{BlockHeader, SlotId, StakingAddress}
-import org.plasmalabs.models._
-import org.plasmalabs.models.utility._
+import org.plasmalabs.models.*
+import org.plasmalabs.models.utility.*
 import org.plasmalabs.node.models.BlockBody
 import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.models.box.{Box, Value}


### PR DESCRIPTION
## Purpose

Update the formatting of imports so that it uses Scala3


## Approach

Scalafix did it for me.

## Testing

If code compiles and tests pass it is OK

## Tickets

* Done as part of TSDK-916