### PR TITLE
Orientdb_wallErrors_suggestion8672

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -2,5 +2,6 @@
 -Xms1G
 -Xss32M
 -Dstorage.diskCache.bufferSize=4096
+-Dstorage.wal.allowDirectIO=false
 -Denvironment.dumpCfgAtStartup=false
 -Dmemory.useUnsafe=false


### PR DESCRIPTION
## Purpose 

Sometimes,  when integration test finished with success, the pipeline fails. 
I am not sure if this will solve the issue but, for example, this change on a setting in the jvm param, complete the pipeline in the first commit. The suggestion of this setting is described on issue 6672


- - https://github.com/orientechnologies/orientdb/issues/8672

[info] Passed: Total 6, Failed 0, Errors 0, Passed 6
[success] Total time: 562 s (09:22), completed Nov 25, 2024, 2:07:57 PM
2024-11-25 14:07:57.247Z  info [Orient] Orient Engine is shutting down... 
2024-11-25 14:07:57.249Z  info [OrientDBEmbedded] - shutdown storage: orient-db ... 
**malloc(): unsorted double linked list corrupted**
/home/runner/work/_temp/f2069c89-a84c-4095-b504-1f06e058ec9c.sh: line 1:  1979 Aborted                 (core dumped) sbt nodeIt/test

- 