### PR TITLE
CryptoResources Parallelism Fix

### DIFF
--- a/blockchain-core/src/main/scala/org/plasmalabs/blockchain/CryptoResources.scala
+++ b/blockchain-core/src/main/scala/org/plasmalabs/blockchain/CryptoResources.scala
@@ -19,8 +19,7 @@ object CryptoResources {
   def make[F[_]: Async]: F[CryptoResources[F]] =
     Async[F]
       // Limit the number of each resource to the number of available processors,
-      // but with a minimum of 4 to avoid scarcity
-      .delay((Runtime.getRuntime.availableProcessors() - 1).min(1))
+      .delay((Runtime.getRuntime.availableProcessors() - 1).max(1))
       .flatMap(maxParallelism =>
         (
           CatsUnsafeResource.make[F, Blake2b256](new Blake2b256, maxParallelism),


### PR DESCRIPTION
## Purpose
- The current logic for the parallelism of crypto resources is incorrect.
  - On 2+ CPU machines, the logic will force them all to a parallelism of 1
  - On 1 CPU machines, the node fails to launch
## Approach
- Fix `.min` to be `.max`
  - Example on 8-CPU machine: `(8 - 1).max(1)` is `7`
  - Example on 1-CPU machine: `(1-1).max(1)` is `1`
## Testing
- Initially observed issue when testing on DigitalOcean 1 CPU droplets
## Tickets
N/A