### PR TITLE
bn_IndexerApp_Parameters_discover

### DIFF
--- a/indexer/src/main/resources/application.conf
+++ b/indexer/src/main/resources/application.conf
@@ -7,14 +7,35 @@ node-rpc-host = "0.0.0.0"
 // The port for the Node RPC Client (i.e. 9084)
 node-rpc-port = 9084
 // Flag indicating if TLS should be used when connecting to the node.
-node-rpc-tls = true
+node-rpc-tls = false
 // Directory to use for the local database
-data-dir = "foo"
+data-dir = "/tmp/indexer/data"
 // The password to use when interacting with OrientDB
 orient-db-password = "plasma"
 // Indexer_db data replicator from node data enabled
 enable-replicator = true
-// Flag indicating if Prometheus metrics should be generated.
-enable-metrics = false
 // Ttl cache indexer rpc call sync with node check
 ttl-cache-check = 1 minutes
+
+kamon {
+  # Enable/disable monitoring
+  enable = true
+
+  environment.service = "indexer"
+
+  trace.join-remote-parents-with-same-span-id = yes
+  metric.tick-interval = 30 seconds
+
+  modules {
+    process-metrics.enabled = no
+    host-metrics.enabled = no
+  }
+
+  prometheus {
+    include-environment-tags = true
+    embedded-server {
+      hostname = 0.0.0.0
+      port = 9095
+    }
+  }
+}

--- a/indexer/src/main/resources/application.conf
+++ b/indexer/src/main/resources/application.conf
@@ -1,44 +1,20 @@
-indexer {
-  enable = true
-
-  // The _base_ directory in which genus_db data is stored
-  // optionally if OrientDB Studio was previously installed required, the genus_db storage should be a child of ¨database¨ folder
-  // Example = "../../orientdb-community-3.2.18/databases/genus_db"
-  // If an empty string is provided, the node's data directory will be used
-  orient-db-directory = ""
-
-  // see https://orientdb.com/docs/last/security/OrientDB-Security-Guide.html
-  // By default, when a new database is created, three default roles and their respective users are created.
-  // The roles are admin, reader, and writer. Three users are also created corresponding to each role: admin, reader, and writer.
-  // A default password is also created for each user. The password is the same as the user's name (e.g., the admin user's password is set to admin).
-  // Node application steps:
-  //  - start orient-db server with credentials admin, admin
-  //  - create db schemas
-  //  - update user admin using password provided
-  orient-db-password = "topl"
-  // Indexer cache time to live, which provide replica status and enable or not the Indexer Grpc services
-  ttl-cache-check = 1 minutes
-}
-
-kamon {
-  # Enable/disable monitoring
-  enable = true
-
-  environment.service = "genus"
-
-  trace.join-remote-parents-with-same-span-id = yes
-  metric.tick-interval = 5 seconds
-
-  modules {
-    process-metrics.enabled = no
-    host-metrics.enabled = no
-  }
-
-  prometheus {
-    include-environment-tags = true
-    embedded-server {
-      hostname = 0.0.0.0
-      port = 9095
-    }
-  }
-}
+// The host to bind for the RPC layer (i.e. 0.0.0.0)
+rpc-bind-host = "0.0.0.0"
+// The port to bind for the RPC layer (i.e. 9084)
+rpc-bind-port = 9084
+// The host for the Node RPC Client (i.e. localhost)
+node-rpc-host = "0.0.0.0"
+// The port for the Node RPC Client (i.e. 9084)
+node-rpc-port = 9084
+// Flag indicating if TLS should be used when connecting to the node.
+node-rpc-tls = true
+// Directory to use for the local database
+data-dir = "foo"
+// The password to use when interacting with OrientDB
+orient-db-password = "plasma"
+// Indexer_db data replicator from node data enabled
+enable-replicator = true
+// Flag indicating if Prometheus metrics should be generated.
+enable-metrics = false
+// Ttl cache indexer rpc call sync with node check
+ttl-cache-check = 1 minutes

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -3,11 +3,13 @@ package org.plasmalabs.indexer
 import cats.Show
 import cats.effect.IO
 import cats.implicits.*
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
 import kamon.Kamon
 import mainargs.{Flag, ParserForClass, arg, main}
+import monocle.*
+import monocle.macros.*
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs, IOBaseApp, YamlConfig}
+import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs, IOBaseApp}
 import org.plasmalabs.grpc.{Grpc, HealthCheckGrpc}
 import org.plasmalabs.interpreters.KamonStatsRef
 import org.plasmalabs.node.services.NodeRpcFs2Grpc
@@ -20,9 +22,9 @@ import scala.concurrent.duration.Duration
 object IndexerApp
     extends IOBaseApp[IndexerArgs, IndexerApplicationConfig](
       createArgs = a => IO.delay(IndexerArgs.parserArgs.constructOrThrow(a)),
-      createConfig = IOBaseApp.createTypesafeConfig(_),
+      createConfig = IOBaseApp.createTypesafeConfig(_, Option("INDEXER_CONFIG_FILE")),
       parseConfig = (args, conf) => IO.delay(IndexerApplicationConfig.unsafe(args, conf)),
-      preInitFunction = config => IO.delay(if (config.enableMetrics) Kamon.init())
+      preInitFunction = config => IO.delay(if (config.kamon.enable) Kamon.init())
     ) {
 
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName("IndexerApp")
@@ -97,8 +99,6 @@ object IndexerArgs {
     orientDbPassword: Option[String] = None,
     @arg(doc = "Flag indicating if data should be copied from the node to the local database")
     enableReplicator: Option[Boolean] = None,
-    @arg(doc = "Flag indicating if Prometheus metrics should be generated.")
-    enableMetrics: Option[Boolean] = None,
     @arg(doc = "Ttl cache indexer rpc call sync with node check")
     ttlCacheCheck: Option[String] = None
   )
@@ -127,7 +127,6 @@ object IndexerArgs {
       show" nodeRpcPort=${args.runtime.nodeRpcPort}" +
       show" dataDir=${args.runtime.dataDir}" +
       show" enableReplicator=${args.runtime.enableReplicator}" +
-      show" enableMetrics=${args.runtime.enableMetrics}" +
       show" ttlCacheCheck=${args.runtime.ttlCacheCheck}" +
       // NOTE: Do not show orientDbPassword
       show")"
@@ -142,30 +141,36 @@ case class IndexerApplicationConfig(
   dataDir:          String,
   orientDbPassword: String,
   enableReplicator: Boolean = false,
-  enableMetrics:    Boolean = false,
-  ttlCacheCheck:    Duration
+  ttlCacheCheck:    Duration,
+  kamon:            KamonConfig
 ) derives ConfigReader
+
+case class KamonConfig(enable: Boolean)
 
 object IndexerApplicationConfig {
 
   def unsafe(args: IndexerArgs, config: Config): IndexerApplicationConfig = {
-    println(config)
-    val argsAsConfig = {
-      val entries = List(
-        args.runtime.rpcBindHost.map("rpc-bind-host: " + _),
-        args.runtime.rpcBindPort.map("rpc-bind-port: " + _),
-        args.runtime.nodeRpcHost.map("node-rpc-host: " + _),
-        args.runtime.nodeRpcPort.map("node-rpc-port: " + _),
-        args.runtime.nodeRpcTls.map("node-rpc-tls: " + _),
-        args.runtime.dataDir.map("data-dir: " + _),
-        args.runtime.orientDbPassword.map("orient-db-password: " + _),
-        args.runtime.enableReplicator.map("enable-replicator: " + _),
-        args.runtime.enableMetrics.map("enable-metrics: " + _)
-      ).flatten
-      if (entries.isEmpty) ConfigFactory.empty() else YamlConfig.parse(entries.mkString("\n"))
-    }
 
-    ConfigSource.fromConfig(config.withFallback(argsAsConfig)).loadOrThrow[IndexerApplicationConfig]
+    val base = ConfigSource.fromConfig(config).loadOrThrow[IndexerApplicationConfig]
+    println(config)
+    def createF[B](lens: Lens[IndexerApplicationConfig, B])(
+      value: B
+    ): IndexerApplicationConfig => IndexerApplicationConfig =
+      (appConf: IndexerApplicationConfig) => lens.replace(value)(appConf)
+
+    val argsAsConfig =
+      List[Option[IndexerApplicationConfig => IndexerApplicationConfig]](
+        args.runtime.rpcBindHost.map(createF(GenLens[IndexerApplicationConfig](_.rpcBindHost))),
+        args.runtime.rpcBindPort.map(createF(GenLens[IndexerApplicationConfig](_.rpcBindPort))),
+        args.runtime.nodeRpcHost.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcHost))),
+        args.runtime.nodeRpcPort.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcPort))),
+        args.runtime.nodeRpcTls.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcTls))),
+        args.runtime.dataDir.map(createF(GenLens[IndexerApplicationConfig](_.dataDir))),
+        args.runtime.orientDbPassword.map(createF(GenLens[IndexerApplicationConfig](_.orientDbPassword))),
+        args.runtime.enableReplicator.map(createF(GenLens[IndexerApplicationConfig](_.enableReplicator)))
+      ).flatten.foldLeft(base)((appConf, f) => f(appConf))
+
+    argsAsConfig
   }
 
   implicit val showApplicationConfig: Show[IndexerApplicationConfig] =

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerTransactionService.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerTransactionService.scala
@@ -2,14 +2,13 @@ package org.plasmalabs.indexer
 
 import cats.data.EitherT
 import cats.effect.kernel.Async
-import cats.implicits._
-import org.plasmalabs.indexer.services._
+import cats.implicits.*
+import fs2.Stream
+import io.grpc.Metadata
 import org.plasmalabs.indexer.algebras.TransactionFetcherAlgebra
 import org.plasmalabs.indexer.model.GEs
-import org.plasmalabs.typeclasses.implicits._
-
-import io.grpc.Metadata // scalafix:ok
-import fs2._ // scalafix:ok
+import org.plasmalabs.indexer.services.*
+import org.plasmalabs.typeclasses.implicits.*
 
 class GrpcTransactionService[F[_]: Async](transactionFetcher: TransactionFetcherAlgebra[F])
     extends TransactionServiceFs2Grpc[F, Metadata] {

--- a/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/ApplicationConfig.scala
+++ b/network-delayer/src/main/scala/org/plasmalabs/networkdelayer/ApplicationConfig.scala
@@ -2,7 +2,6 @@ package org.plasmalabs.networkdelayer
 
 import cats.Show
 import com.typesafe.config.Config
-import pureconfig.generic.derivation.default.*
 import pureconfig.{ConfigSource, *}
 
 import scala.concurrent.duration.FiniteDuration


### PR DESCRIPTION
## Purpose

```
docker run -p 9084:9084 --rm ghcr.io/plasmalaboratories/plasma-indexer:0.1.4 --node-rpc-host localhost --node-rpc-port 9094
pureconfig.error.ConfigReaderException: Cannot convert configuration to a org.plasmalabs.indexer.IndexerApplicationConfig. Failures are:
  at 'data-dir':
    - Key not found: 'data-dir'.
  at 'enable-metrics':
    - Key not found: 'enable-metrics'.
  at 'enable-replicator':
    - Key not found: 'enable-replicator'.
  at 'node-rpc-tls':
    - Key not found: 'node-rpc-tls'.
  at 'orient-db-password':
    - Key not found: 'orient-db-password'.
  at 'rpc-bind-host':
    - Key not found: 'rpc-bind-host'.
  at 'rpc-bind-port':
    - Key not found: 'rpc-bind-port'.
  at 'ttl-cache-check':
    - Key not found: 'ttl-cache-check'.

```
## Approach
- create minimal application.conf for Indexer App, try to build a dev images, and debug if we are able to run it.
- TODO test Startup, Runtime parameters, and evaluate if are required for this application. My understanding in the code was that if Runtime paramters are empty, the Yaml parser fails,  and for this reason I disable it on empty inputs.
- TODO enable again kamon metrics and see if they are reporting as expected

## Testing
@Rick I will need help on your side to deploy on any net that you prefer