### PR TITLE
Additional fixes for Indexer parsing

### DIFF
--- a/indexer/src/main/resources/application.conf
+++ b/indexer/src/main/resources/application.conf
@@ -7,14 +7,35 @@ node-rpc-host = "0.0.0.0"
 // The port for the Node RPC Client (i.e. 9084)
 node-rpc-port = 9084
 // Flag indicating if TLS should be used when connecting to the node.
-node-rpc-tls = true
+node-rpc-tls = false
 // Directory to use for the local database
-data-dir = "foo"
+data-dir = "/tmp/indexer/data"
 // The password to use when interacting with OrientDB
 orient-db-password = "plasma"
 // Indexer_db data replicator from node data enabled
 enable-replicator = true
-// Flag indicating if Prometheus metrics should be generated.
-enable-metrics = false
 // Ttl cache indexer rpc call sync with node check
 ttl-cache-check = 1 minutes
+
+kamon {
+  # Enable/disable monitoring
+  enable = true
+
+  environment.service = "genus"
+
+  trace.join-remote-parents-with-same-span-id = yes
+  metric.tick-interval = 5 seconds
+
+  modules {
+    process-metrics.enabled = no
+    host-metrics.enabled = no
+  }
+
+  prometheus {
+    include-environment-tags = true
+    embedded-server {
+      hostname = 0.0.0.0
+      port = 9095
+    }
+  }
+}

--- a/indexer/src/main/resources/application.conf
+++ b/indexer/src/main/resources/application.conf
@@ -21,10 +21,10 @@ kamon {
   # Enable/disable monitoring
   enable = true
 
-  environment.service = "genus"
+  environment.service = "indexer"
 
   trace.join-remote-parents-with-same-span-id = yes
-  metric.tick-interval = 5 seconds
+  metric.tick-interval = 30 seconds
 
   modules {
     process-metrics.enabled = no

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -122,12 +122,12 @@ object IndexerArgs {
     args =>
       show"IndexerApplicationConfig(" +
       show"rpcBindHost=${args.runtime.rpcBindHost}" +
-      show"rpcBindPort=${args.runtime.rpcBindPort}" +
-      show"nodeRpcHost=${args.runtime.nodeRpcHost}" +
-      show"nodeRpcPort=${args.runtime.nodeRpcPort}" +
-      show"dataDir=${args.runtime.dataDir}" +
-      show"enableReplicator=${args.runtime.enableReplicator}" +
-      show"ttlCacheCheck=${args.runtime.ttlCacheCheck}" +
+      show" rpcBindPort=${args.runtime.rpcBindPort}" +
+      show" nodeRpcHost=${args.runtime.nodeRpcHost}" +
+      show" nodeRpcPort=${args.runtime.nodeRpcPort}" +
+      show" dataDir=${args.runtime.dataDir}" +
+      show" enableReplicator=${args.runtime.enableReplicator}" +
+      show" ttlCacheCheck=${args.runtime.ttlCacheCheck}" +
       // NOTE: Do not show orientDbPassword
       show")"
 }
@@ -178,12 +178,12 @@ object IndexerApplicationConfig {
     config =>
       show"IndexerApplicationConfig(" +
       show"rpcBindHost=${config.rpcBindHost}" +
-      show"rpcBindPort=${config.rpcBindPort}" +
-      show"nodeRpcHost=${config.nodeRpcHost}" +
-      show"nodeRpcPort=${config.nodeRpcPort}" +
-      show"dataDir=${config.dataDir}" +
-      show"enableReplicator=${config.enableReplicator}" +
-      show"ttlCacheCheck=${config.ttlCacheCheck}" +
+      show" rpcBindPort=${config.rpcBindPort}" +
+      show" nodeRpcHost=${config.nodeRpcHost}" +
+      show" nodeRpcPort=${config.nodeRpcPort}" +
+      show" dataDir=${config.dataDir}" +
+      show" enableReplicator=${config.enableReplicator}" +
+      show" ttlCacheCheck=${config.ttlCacheCheck}" +
       // NOTE: Do not show orientDbPassword
       show")"
 }

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -6,6 +6,8 @@ import cats.implicits.*
 import com.typesafe.config.Config
 import kamon.Kamon
 import mainargs.{Flag, ParserForClass, arg, main}
+import monocle.*
+import monocle.macros.*
 import org.plasmalabs.algebras.Stats
 import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs, IOBaseApp}
 import org.plasmalabs.grpc.{Grpc, HealthCheckGrpc}
@@ -14,8 +16,6 @@ import org.plasmalabs.node.services.NodeRpcFs2Grpc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import pureconfig.{ConfigSource, *}
-import monocle.*
-import monocle.macros.*
 
 import scala.concurrent.duration.Duration
 

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -3,26 +3,28 @@ package org.plasmalabs.indexer
 import cats.Show
 import cats.effect.IO
 import cats.implicits.*
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.Config
 import kamon.Kamon
 import mainargs.{Flag, ParserForClass, arg, main}
 import org.plasmalabs.algebras.Stats
-import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs, IOBaseApp, YamlConfig}
+import org.plasmalabs.common.application.{ContainsDebugFlag, ContainsUserConfigs, IOBaseApp}
 import org.plasmalabs.grpc.{Grpc, HealthCheckGrpc}
 import org.plasmalabs.interpreters.KamonStatsRef
 import org.plasmalabs.node.services.NodeRpcFs2Grpc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import pureconfig.{ConfigSource, *}
+import monocle.*
+import monocle.macros.*
 
 import scala.concurrent.duration.Duration
 
 object IndexerApp
     extends IOBaseApp[IndexerArgs, IndexerApplicationConfig](
       createArgs = a => IO.delay(IndexerArgs.parserArgs.constructOrThrow(a)),
-      createConfig = IOBaseApp.createTypesafeConfig(_),
+      createConfig = IOBaseApp.createTypesafeConfig(_, Option("INDEXER_CONFIG_FILE")),
       parseConfig = (args, conf) => IO.delay(IndexerApplicationConfig.unsafe(args, conf)),
-      preInitFunction = config => IO.delay(if (config.enableMetrics) Kamon.init())
+      preInitFunction = config => IO.delay(if (config.kamon.enable) Kamon.init())
     ) {
 
   implicit val logger: Logger[F] = Slf4jLogger.getLoggerFromName("IndexerApp")
@@ -97,8 +99,6 @@ object IndexerArgs {
     orientDbPassword: Option[String] = None,
     @arg(doc = "Flag indicating if data should be copied from the node to the local database")
     enableReplicator: Option[Boolean] = None,
-    @arg(doc = "Flag indicating if Prometheus metrics should be generated.")
-    enableMetrics: Option[Boolean] = None,
     @arg(doc = "Ttl cache indexer rpc call sync with node check")
     ttlCacheCheck: Option[String] = None
   )
@@ -122,13 +122,12 @@ object IndexerArgs {
     args =>
       show"IndexerApplicationConfig(" +
       show"rpcBindHost=${args.runtime.rpcBindHost}" +
-      show" rpcBindPort=${args.runtime.rpcBindPort}" +
-      show" nodeRpcHost=${args.runtime.nodeRpcHost}" +
-      show" nodeRpcPort=${args.runtime.nodeRpcPort}" +
-      show" dataDir=${args.runtime.dataDir}" +
-      show" enableReplicator=${args.runtime.enableReplicator}" +
-      show" enableMetrics=${args.runtime.enableMetrics}" +
-      show" ttlCacheCheck=${args.runtime.ttlCacheCheck}" +
+      show"rpcBindPort=${args.runtime.rpcBindPort}" +
+      show"nodeRpcHost=${args.runtime.nodeRpcHost}" +
+      show"nodeRpcPort=${args.runtime.nodeRpcPort}" +
+      show"dataDir=${args.runtime.dataDir}" +
+      show"enableReplicator=${args.runtime.enableReplicator}" +
+      show"ttlCacheCheck=${args.runtime.ttlCacheCheck}" +
       // NOTE: Do not show orientDbPassword
       show")"
 }
@@ -143,41 +142,48 @@ case class IndexerApplicationConfig(
   orientDbPassword: String,
   enableReplicator: Boolean = false,
   enableMetrics:    Boolean = false,
-  ttlCacheCheck:    Duration
+  ttlCacheCheck:    Duration,
+  kamon:            KamonConfig
 ) derives ConfigReader
+
+case class KamonConfig(enable: Boolean)
 
 object IndexerApplicationConfig {
 
   def unsafe(args: IndexerArgs, config: Config): IndexerApplicationConfig = {
-    println(config)
-    val argsAsConfig = {
-      val entries = List(
-        args.runtime.rpcBindHost.map("rpc-bind-host: " + _),
-        args.runtime.rpcBindPort.map("rpc-bind-port: " + _),
-        args.runtime.nodeRpcHost.map("node-rpc-host: " + _),
-        args.runtime.nodeRpcPort.map("node-rpc-port: " + _),
-        args.runtime.nodeRpcTls.map("node-rpc-tls: " + _),
-        args.runtime.dataDir.map("data-dir: " + _),
-        args.runtime.orientDbPassword.map("orient-db-password: " + _),
-        args.runtime.enableReplicator.map("enable-replicator: " + _),
-        args.runtime.enableMetrics.map("enable-metrics: " + _)
-      ).flatten
-      if (entries.isEmpty) ConfigFactory.empty() else YamlConfig.parse(entries.mkString("\n"))
-    }
 
-    ConfigSource.fromConfig(config.withFallback(argsAsConfig)).loadOrThrow[IndexerApplicationConfig]
+    val base = ConfigSource.fromConfig(config).loadOrThrow[IndexerApplicationConfig]
+    println(config)
+    def createF[B](lens: Lens[IndexerApplicationConfig, B])(
+      value: B
+    ): IndexerApplicationConfig => IndexerApplicationConfig =
+      (appConf: IndexerApplicationConfig) => lens.replace(value)(appConf)
+
+    val argsAsConfig =
+      List[Option[IndexerApplicationConfig => IndexerApplicationConfig]](
+        args.runtime.rpcBindHost.map(createF(GenLens[IndexerApplicationConfig](_.rpcBindHost))),
+        args.runtime.rpcBindPort.map(createF(GenLens[IndexerApplicationConfig](_.rpcBindPort))),
+        args.runtime.nodeRpcHost.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcHost))),
+        args.runtime.nodeRpcPort.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcPort))),
+        args.runtime.nodeRpcTls.map(createF(GenLens[IndexerApplicationConfig](_.nodeRpcTls))),
+        args.runtime.dataDir.map(createF(GenLens[IndexerApplicationConfig](_.dataDir))),
+        args.runtime.orientDbPassword.map(createF(GenLens[IndexerApplicationConfig](_.orientDbPassword))),
+        args.runtime.enableReplicator.map(createF(GenLens[IndexerApplicationConfig](_.enableReplicator)))
+      ).flatten.foldLeft(base)((appConf, f) => f(appConf))
+
+    argsAsConfig
   }
 
   implicit val showApplicationConfig: Show[IndexerApplicationConfig] =
     config =>
       show"IndexerApplicationConfig(" +
       show"rpcBindHost=${config.rpcBindHost}" +
-      show" rpcBindPort=${config.rpcBindPort}" +
-      show" nodeRpcHost=${config.nodeRpcHost}" +
-      show" nodeRpcPort=${config.nodeRpcPort}" +
-      show" dataDir=${config.dataDir}" +
-      show" enableReplicator=${config.enableReplicator}" +
-      show" ttlCacheCheck=${config.ttlCacheCheck}" +
+      show"rpcBindPort=${config.rpcBindPort}" +
+      show"nodeRpcHost=${config.nodeRpcHost}" +
+      show"nodeRpcPort=${config.nodeRpcPort}" +
+      show"dataDir=${config.dataDir}" +
+      show"enableReplicator=${config.enableReplicator}" +
+      show"ttlCacheCheck=${config.ttlCacheCheck}" +
       // NOTE: Do not show orientDbPassword
       show")"
 }

--- a/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
+++ b/indexer/src/main/scala/org/plasmalabs/indexer/IndexerApp.scala
@@ -141,7 +141,6 @@ case class IndexerApplicationConfig(
   dataDir:          String,
   orientDbPassword: String,
   enableReplicator: Boolean = false,
-  enableMetrics:    Boolean = false,
   ttlCacheCheck:    Duration,
   kamon:            KamonConfig
 ) derives ConfigReader


### PR DESCRIPTION
## Purpose
Fixes for merging config + additional changes to make Kamon metrics work

I copied the Node parsing logic where it will first load the base `application.conf` file, and then override any values that are explicitly set via args. This way, we can retain default values.

To get Kamon working, 2 steps are required:
* A `kamon {}` config block in `application.conf` which the library will parse itself
* `Kamon.init()` is called

I moved the `enable-metrics` arg to just be configured in the `kamon` block since that needs to be configured anyways.

## Approach
* Add logic to merge config and args
* Remove `enableMetrics` flag

## Testing
* Ran locally

## Tickets
* n/a
